### PR TITLE
Add human readable description of parsed cron-patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the Rust flavor of the popular JavaScript/TypeScript cron parser
 
 - Parse and evaluate [cron](https://en.wikipedia.org/wiki/Cron#CRON_expression)
   expressions to calculate upcoming execution times.
+- Generates human-readable descriptions of cron patterns.
 - Follows POSIX/Vixie-cron standards, while extending it with additional specifiers such as `L`
   for the last day and weekday of the month, `#` for the nth weekday of the
   month, `W` for closest weekday to a day of month.
@@ -44,6 +45,7 @@ Weekday/Month text representations |  X   |    X    |   X   |
 Aliases (`@hourly` etc.) |  X           |     X      |          |
 chrono `DateTime` compatibility |    X     |     X   |   X    |
 DOM-and-DOW option |    X     |           |         |
+Generate human readable string |    X     |           |    X    |
 
 > **Note**
 > Tests carried out at 2023-12-02 using `cron@0.12.0` and `saffron@.0.1.0`
@@ -88,6 +90,7 @@ fn main() {
     let next = cron_all.find_next_occurrence(&time, false).unwrap();
 
     // Output results
+    println!("Description: {}", cron.describe());
     println!("Time is: {}", time);
     println!("Pattern \"{}\" does {} time {}", cron_all.pattern.to_string(), if matches_all { "match" } else { "not match" }, time );
     println!("Pattern \"{}\" will match next time at {}", cron_all.pattern.to_string(), next);
@@ -279,7 +282,7 @@ To start developing in the Croner project:
 2. Navigate into the project directory.
 3. Build the project using `cargo build`.
 4. Run tests with `cargo test`.
-5. Run demo with `cargo run --example pattern_demo`
+5. Run demo with `cargo run --example simple_demo`
 
 ## Contributing
 

--- a/examples/simple_demo.rs
+++ b/examples/simple_demo.rs
@@ -1,5 +1,6 @@
 use chrono::Local;
 use croner::Cron;
+use croner::describe::lang::swedish::Swedish; // For demonstrating translation
 
 fn main() {
     // Example: Parse cron expression
@@ -15,6 +16,14 @@ fn main() {
     // Example: Get next match
     let next = cron.find_next_occurrence(&time, false).unwrap();
 
+    // Example: Get and print the human-readable description
+    let description = cron.describe();
+    println!("Description: {}", description);
+    
+    // Example: Get and print the human-readable description in Swedish
+    let swedish_description = cron.describe_lang(Swedish::default()); // 2. Call describe_lang() with Swedish
+    println!("Swedish Description: {}", swedish_description);
+    
     // Example: Output results
     println!("Current time is: {time}");
     println!(

--- a/src/describe/lang/english.rs
+++ b/src/describe/lang/english.rs
@@ -1,0 +1,52 @@
+use crate::describe::Language;
+
+#[derive(Default, Clone, Copy)]
+pub struct English;
+
+impl Language for English {
+    fn every_minute(&self) -> &'static str { "Every minute" }
+    fn every_second_phrase(&self) -> &'static str { "Every second" }
+    fn every_x_minutes(&self, s: u8) -> String { format!("every {} minutes", s) }
+    fn every_x_seconds(&self, s: u8) -> String { format!("every {} seconds", s) }
+    fn every_x_hours(&self, s: u8) -> String { format!("of every {} hours", s) }
+    fn every_minute_of_every_x_hours(&self, s: u8) -> String { format!("Every minute, of every {} hours", s) }
+    
+    fn at_time(&self, time: &str) -> String { format!("At {}", time) }
+    fn at_time_and_every_x_seconds(&self, time: &str, step: u8) -> String { format!("At {}, every {} seconds", time, step) }
+    fn at_time_at_second(&self, time: &str, second: &str) -> String { format!("At {}, at second {}", time, second) }
+    
+    fn at_phrase(&self, phrase: &str) -> String { format!("At {}", phrase) }
+    fn on_phrase(&self, phrase: &str) -> String { format!("on {}", phrase) }
+    fn in_phrase(&self, phrase: &str) -> String { format!("in {}", phrase) }
+    
+    fn second_phrase(&self, s: &str) -> String { format!("second {}", s) }
+    fn minute_phrase(&self, s: &str) -> String { format!("minute {}", s) }
+    fn minute_past_every_hour_phrase(&self, s: &str) -> String { format!("{} past every hour", s) }
+    fn hour_phrase(&self, s: &str) -> String { format!("of hour {}", s) }
+
+    fn day_phrase(&self, s: &str) -> String { format!("day {}", s) }
+    fn the_last_day_of_the_month(&self) -> &'static str { "the last day of the month" }
+    fn the_weekday_nearest_day(&self, day: &str) -> String { format!("the weekday nearest day {}", day) }
+    fn the_last_weekday_of_the_month(&self, day: &str) -> String { format!("the last {} of the month", day) }
+    
+    fn the_nth_weekday_of_the_month(&self, n: u8, day: &str) -> String {
+        let suffix = match n {
+            1 => "st",
+            2 => "nd",
+            3 => "rd",
+            _ => "th",
+        };
+        let num_str = format!("{}{}", n, suffix);
+        format!("the {} {} of the month", num_str, day)
+    }
+
+    fn dom_and_dow_if_also(&self, dow: &str) -> String { format!("(if it is also {})", dow) }
+    fn dom_and_dow_if_also_one_of(&self, dow: &str) -> String { format!("(if it is also one of: {})", dow) }
+
+    fn list_conjunction_and(&self) -> &'static str { " and " }
+    fn list_conjunction_or(&self) -> &'static str { " or " }
+    fn list_conjunction_and_comma(&self) -> &'static str { ", and " }
+    
+    fn day_of_week_names(&self) -> [&'static str; 7] { ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] }
+    fn month_names(&self) -> [&'static str; 12] { ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] }
+}

--- a/src/describe/lang/english.rs
+++ b/src/describe/lang/english.rs
@@ -43,9 +43,9 @@ impl Language for English {
     fn dom_and_dow_if_also(&self, dow: &str) -> String { format!("(if it is also {})", dow) }
     fn dom_and_dow_if_also_one_of(&self, dow: &str) -> String { format!("(if it is also one of: {})", dow) }
 
-    fn list_conjunction_and(&self) -> &'static str { " and " }
-    fn list_conjunction_or(&self) -> &'static str { " or " }
-    fn list_conjunction_and_comma(&self) -> &'static str { ", and " }
+    fn list_conjunction_and(&self) -> &'static str { "and" }
+    fn list_conjunction_or(&self) -> &'static str { "or" }
+    fn list_conjunction_and_comma(&self) -> &'static str { ", and" }
     
     fn day_of_week_names(&self) -> [&'static str; 7] { ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] }
     fn month_names(&self) -> [&'static str; 12] { ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] }

--- a/src/describe/lang/mod.rs
+++ b/src/describe/lang/mod.rs
@@ -1,0 +1,2 @@
+pub mod english;
+pub mod swedish;

--- a/src/describe/lang/swedish.rs
+++ b/src/describe/lang/swedish.rs
@@ -1,0 +1,53 @@
+use crate::describe::Language;
+
+#[derive(Default, Clone, Copy)]
+pub struct Swedish;
+
+impl Language for Swedish {
+    fn every_minute(&self) -> &'static str { "Varje minut" }
+    fn every_second_phrase(&self) -> &'static str { "Varje sekund" }
+    fn every_x_minutes(&self, s: u8) -> String { format!("var {}:e minut", s) }
+    fn every_x_seconds(&self, s: u8) -> String { format!("var {}:e sekund", s) }
+    fn every_x_hours(&self, s: u8) -> String { format!("var {}:e timme", s) }
+    fn every_minute_of_every_x_hours(&self, s: u8) -> String { format!("Varje minut, var {}:e timme", s) }
+    
+    fn at_time(&self, time: &str) -> String { format!("Klockan {}", time) }
+    fn at_time_and_every_x_seconds(&self, time: &str, step: u8) -> String { format!("Klockan {}, var {}:e sekund", time, step) }
+    fn at_time_at_second(&self, time: &str, second: &str) -> String { format!("Klockan {}, på sekund {}", time, second) }
+    
+    fn at_phrase(&self, phrase: &str) -> String { format!("Vid {}", phrase) }
+    fn on_phrase(&self, phrase: &str) -> String { format!("på {}", phrase) }
+    fn in_phrase(&self, phrase: &str) -> String { format!("i {}", phrase) }
+    
+    fn second_phrase(&self, s: &str) -> String { format!("sekund {}", s) }
+    fn minute_phrase(&self, s: &str) -> String { format!("minut {}", s) }
+    fn minute_past_every_hour_phrase(&self, s: &str) -> String { format!("{} över varje heltimme", s) }
+    fn hour_phrase(&self, s: &str) -> String { format!("timme {}", s) }
+
+    fn day_phrase(&self, s: &str) -> String { format!("dag {}", s) }
+    fn the_last_day_of_the_month(&self) -> &'static str { "sista dagen i månaden" }
+    fn the_weekday_nearest_day(&self, day: &str) -> String { format!("veckodagen närmast dag {}", day) }
+    fn the_last_weekday_of_the_month(&self, day: &str) -> String { format!("sista {} i månaden", day) }
+    
+    fn the_nth_weekday_of_the_month(&self, n: u8, day: &str) -> String {
+        let ordinal = match n {
+            1 => "första",
+            2 => "andra",
+            3 => "tredje",
+            4 => "fjärde",
+            5 => "femte",
+            _ => "", // Should not happen with cron's # specifier
+        };
+        format!("den {} {} i månaden", ordinal, day)
+    }
+
+    fn dom_and_dow_if_also(&self, dow: &str) -> String { format!("(om det också är {})", dow) }
+    fn dom_and_dow_if_also_one_of(&self, dow: &str) -> String { format!("(om det också är en av: {})", dow) }
+
+    fn list_conjunction_and(&self) -> &'static str { " och " }
+    fn list_conjunction_or(&self) -> &'static str { " eller " }
+    fn list_conjunction_and_comma(&self) -> &'static str { " och " } // Oxford comma is not used in Swedish
+    
+    fn day_of_week_names(&self) -> [&'static str; 7] { ["söndag", "måndag", "tisdag", "onsdag", "torsdag", "fredag", "lördag"] }
+    fn month_names(&self) -> [&'static str; 12] { ["januari", "februari", "mars", "april", "maj", "juni", "juli", "augusti", "september", "oktober", "november", "december"] }
+}

--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -1,0 +1,463 @@
+// src/describe/mod.rs
+
+pub mod lang;
+pub use lang::english::English;
+
+use crate::component::{
+    CronComponent, ALL_BIT, CLOSEST_WEEKDAY_BIT, LAST_BIT, NTH_1ST_BIT, NTH_2ND_BIT, NTH_3RD_BIT,
+    NTH_4TH_BIT, NTH_5TH_BIT,
+};
+use crate::pattern::CronPattern;
+
+// This defines the contract for providing localized strings.
+pub trait Language {
+    fn every_minute(&self) -> &'static str;
+    fn every_second_phrase(&self) -> &'static str;
+    fn every_x_minutes(&self, step: u8) -> String;
+    fn every_x_seconds(&self, step: u8) -> String;
+    fn every_x_hours(&self, step: u8) -> String;
+    fn every_minute_of_every_x_hours(&self, step: u8) -> String;
+
+    fn at_time(&self, time: &str) -> String;
+    fn at_time_and_every_x_seconds(&self, time: &str, step: u8) -> String;
+    fn at_time_at_second(&self, time: &str, second: &str) -> String;
+    
+    fn at_phrase(&self, phrase: &str) -> String;
+    fn on_phrase(&self, phrase: &str) -> String;
+    fn in_phrase(&self, phrase: &str) -> String;
+
+    fn second_phrase(&self, s: &str) -> String;
+    fn minute_phrase(&self, s: &str) -> String;
+    fn minute_past_every_hour_phrase(&self, s: &str) -> String;
+    fn hour_phrase(&self, s: &str) -> String;
+
+    fn day_phrase(&self, s: &str) -> String;
+    fn the_last_day_of_the_month(&self) -> &'static str;
+    fn the_weekday_nearest_day(&self, day: &str) -> String;
+    fn the_last_weekday_of_the_month(&self, day: &str) -> String;
+    fn the_nth_weekday_of_the_month(&self, n: u8, day: &str) -> String;
+
+    fn dom_and_dow_if_also(&self, dow: &str) -> String;
+    fn dom_and_dow_if_also_one_of(&self, dow: &str) -> String;
+
+    fn list_conjunction_and(&self) -> &'static str;
+    fn list_conjunction_or(&self) -> &'static str;
+    fn list_conjunction_and_comma(&self) -> &'static str;
+    
+    fn day_of_week_names(&self) -> [&'static str; 7];
+    fn month_names(&self) -> [&'static str; 12];
+}
+
+/// Generates a human-readable description for a `CronPattern`.
+pub fn describe<L: Language>(pattern: &CronPattern, lang: &L) -> String {
+    let time_desc = describe_time(pattern, lang);
+    let day_desc = describe_day(pattern, lang);
+    let month_desc = describe_month(pattern, lang);
+
+    let mut parts = vec![];
+    if !time_desc.is_empty() {
+        parts.push(time_desc);
+    }
+    if !day_desc.is_empty() {
+        parts.push(day_desc);
+    }
+    if !month_desc.is_empty() {
+        parts.push(month_desc);
+    }
+
+    let mut description = parts.join(", ");
+    if !description.is_empty() {
+        let mut chars = description.chars();
+        description = match chars.next() {
+            None => String::new(),
+            Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+        };
+        description.push('.');
+    }
+    description
+}
+
+fn describe_time<L: Language>(pattern: &CronPattern, lang: &L) -> String {
+    let has_seconds = pattern.with_seconds_optional || pattern.with_seconds_required;
+    let sec_vals = get_set_values(&pattern.seconds, ALL_BIT);
+    let min_vals = get_set_values(&pattern.minutes, ALL_BIT);
+    let hour_vals = get_set_values(&pattern.hours, ALL_BIT);
+
+    let is_default_seconds = !has_seconds || (pattern.seconds.step == 1 && sec_vals.len() == 1 && sec_vals[0] == 0);
+    let is_every_second = has_seconds && pattern.seconds.is_all_set();
+
+    // Handle simplest cases first
+    if is_every_second && pattern.minutes.is_all_set() && pattern.hours.is_all_set() {
+        return lang.every_second_phrase().to_string();
+    }
+    if is_default_seconds && pattern.minutes.is_all_set() && pattern.hours.is_all_set() {
+        return lang.every_minute().to_string();
+    }
+    if is_default_seconds && pattern.minutes.from_wildcard && pattern.minutes.step > 1 && pattern.hours.is_all_set() {
+        return lang.at_phrase(&lang.every_x_minutes(pattern.minutes.step));
+    }
+
+    // Handle specific HH:MM time
+    if !is_every_second && pattern.hours.step == 1 && hour_vals.len() == 1 && pattern.minutes.step == 1 && min_vals.len() == 1 {
+        let hour = hour_vals[0];
+        let minute = min_vals[0];
+        let time_str = format!("{:02}:{:02}", hour, minute);
+        
+        if has_seconds && !is_default_seconds {
+            if pattern.seconds.step > 1 && pattern.seconds.from_wildcard {
+                return lang.at_time_and_every_x_seconds(&time_str, pattern.seconds.step);
+            }
+            if sec_vals.len() == 1 {
+                return lang.at_time(&format!("{}:{:02}", time_str, sec_vals[0]));
+            }
+            return lang.at_time_at_second(&time_str, &format_number_list(&sec_vals, lang));
+        }
+        return lang.at_time(&time_str);
+    }
+
+    // Handle all other complex combinations
+    let mut parts = vec![];
+    
+    if is_every_second {
+        parts.push(lang.every_second_phrase().to_string());
+    } else if has_seconds && !is_default_seconds {
+        // Correctly handle ranged steps vs. wildcard steps
+        if pattern.seconds.step > 1 && pattern.seconds.from_wildcard {
+            parts.push(lang.every_x_seconds(pattern.seconds.step));
+        } else {
+            parts.push(lang.second_phrase(&format_number_list(&sec_vals, lang)));
+        }
+    }
+    
+    if pattern.minutes.from_wildcard && pattern.minutes.step > 1 {
+        parts.push(lang.every_x_minutes(pattern.minutes.step));
+    } else if !pattern.minutes.is_all_set() {
+        let min_desc = lang.minute_phrase(&format_number_list(&min_vals, lang));
+        if pattern.hours.is_all_set() && pattern.hours.step == 1 {
+            parts.push(lang.minute_past_every_hour_phrase(&min_desc));
+        } else {
+            parts.push(min_desc);
+        }
+    }
+
+    if !pattern.hours.is_all_set() {
+        if pattern.hours.step > 1 {
+            parts.push(lang.every_x_hours(pattern.hours.step));
+        } else {
+             parts.push(lang.hour_phrase(&format_number_list(&hour_vals, lang)));
+        }
+    }
+
+    if parts.is_empty() {
+        return lang.every_minute().to_string();
+    }
+    
+    if parts.len() > 1 && parts[0] == lang.every_second_phrase() {
+        return parts.join(", ");
+    }
+    
+    lang.at_phrase(&parts.join(", "))
+}
+
+
+fn get_set_values(component: &CronComponent, bit: u8) -> Vec<u8> {
+    (component.min..=component.max)
+        .filter(|&i| component.is_bit_set(i, bit).unwrap_or(false))
+        .collect()
+}
+
+fn format_text_list<L: Language>(items: Vec<String>, lang: &L) -> String {
+    match items.len() {
+        0 => String::new(),
+        1 => items[0].clone(),
+        2 => format!("{}{}{}", items[0], lang.list_conjunction_and(), items[1]),
+        _ => {
+            if let Some(last) = items.last() {
+                let front = &items[..items.len() - 1];
+                format!("{}{}{}", front.join(", "), lang.list_conjunction_and_comma(), last)
+            } else {
+                String::new()
+            }
+        }
+    }
+}
+
+fn format_number_list<L: Language>(values: &[u8], lang: &L) -> String {
+    if values.is_empty() { return String::new(); }
+    let mut sorted_values = values.to_vec();
+    sorted_values.sort_unstable();
+
+    let mut items = vec![];
+    let mut i = 0;
+    while i < sorted_values.len() {
+        let start = sorted_values[i];
+        let mut j = i;
+        while j + 1 < sorted_values.len() && sorted_values[j + 1] == sorted_values[j] + 1 {
+            j += 1;
+        }
+        if j > i {
+            items.push(format!("{}-{}", start, sorted_values[j]));
+        } else {
+            items.push(start.to_string());
+        }
+        i = j + 1;
+    }
+    format_text_list(items, lang)
+}
+
+fn describe_day<L: Language>(pattern: &CronPattern, lang: &L) -> String {
+    let dom_desc = describe_dom(pattern, lang);
+    let dow_parts = describe_dow_parts(pattern, lang);
+
+    if pattern.star_dom && pattern.star_dow {
+        return "".to_string();
+    }
+    
+    if !pattern.star_dom && pattern.star_dow {
+        return lang.on_phrase(&dom_desc);
+    }
+    
+    let dow_desc = format_text_list(dow_parts.clone(), lang);
+    if pattern.star_dom && !pattern.star_dow {
+        return lang.on_phrase(&dow_desc);
+    }
+
+    if pattern.dom_and_dow {
+        let final_phrase = if dow_parts.len() > 1 {
+            lang.dom_and_dow_if_also_one_of(&dow_desc)
+        } else {
+            lang.dom_and_dow_if_also(&dow_desc)
+        };
+        format!("{} {}", lang.on_phrase(&dom_desc), final_phrase)
+    } else {
+        format!("{}{}{}", lang.on_phrase(&dom_desc), lang.list_conjunction_or(), dow_desc)
+    }
+}
+
+fn describe_dom<L: Language>(pattern: &CronPattern, lang: &L) -> String {
+    let mut parts = vec![];
+
+    let regular_days = get_set_values(&pattern.days, ALL_BIT);
+    if !regular_days.is_empty() {
+        parts.push(lang.day_phrase(&format_number_list(&regular_days, lang)));
+    }
+
+    if pattern.days.is_feature_enabled(LAST_BIT) {
+        parts.push(lang.the_last_day_of_the_month().to_string());
+    }
+    let weekday_values = get_set_values(&pattern.days, CLOSEST_WEEKDAY_BIT);
+    if !weekday_values.is_empty() {
+        parts.push(lang.the_weekday_nearest_day(&format_number_list(&weekday_values, lang)));
+    }
+    
+    format_text_list(parts, lang)
+}
+
+fn describe_dow_parts<L: Language>(pattern: &CronPattern, lang: &L) -> Vec<String> {
+    let mut parts = vec![];
+    let dow_names_map = lang.day_of_week_names();
+    let dow_names = if pattern.with_alternative_weekdays {
+        &["", dow_names_map[0], dow_names_map[1], dow_names_map[2], dow_names_map[3], dow_names_map[4], dow_names_map[5], dow_names_map[6]]
+    } else {
+        &[dow_names_map[0], dow_names_map[1], dow_names_map[2], dow_names_map[3], dow_names_map[4], dow_names_map[5], dow_names_map[6], dow_names_map[0]]
+    };
+
+    let last_values = get_set_values(&pattern.days_of_week, LAST_BIT);
+    if !last_values.is_empty() {
+        let days = last_values.iter().map(|&v| dow_names[v as usize].to_string()).collect::<Vec<_>>();
+        parts.push(lang.the_last_weekday_of_the_month(&format_text_list(days, lang)));
+    }
+
+    for (i, nth_bit) in [NTH_1ST_BIT, NTH_2ND_BIT, NTH_3RD_BIT, NTH_4TH_BIT, NTH_5TH_BIT].iter().enumerate() {
+        let values = get_set_values(&pattern.days_of_week, *nth_bit);
+        if !values.is_empty() {
+            let days = values.iter().map(|&v| dow_names[v as usize].to_string()).collect::<Vec<_>>();
+            parts.push(lang.the_nth_weekday_of_the_month((i + 1) as u8, &format_text_list(days, lang)));
+        }
+    }
+
+    let regular_values = get_set_values(&pattern.days_of_week, ALL_BIT);
+    if !regular_values.is_empty() {
+        let is_continuous_range = if regular_values.len() > 2 {
+            regular_values.windows(2).all(|w| w[1] == w[0] + 1)
+        } else { false };
+
+        let list = regular_values.iter().map(|&v| dow_names[v as usize].to_string()).collect::<Vec<_>>();
+        if is_continuous_range {
+            parts.push(list.join(","))
+        } else {
+            parts.push(format_text_list(list, lang));
+        }
+    }
+    parts
+}
+
+fn describe_month<L: Language>(pattern: &CronPattern, lang: &L) -> String {
+    if pattern.months.is_all_set() { return "".to_string(); }
+    let month_names = lang.month_names();
+    
+    if pattern.months.step > 1 {
+        return lang.in_phrase(&format!("every {}rd month", pattern.months.step));
+    }
+    
+    let values = get_set_values(&pattern.months, ALL_BIT);
+    let list = values.iter().map(|&v| month_names[v as usize -1].to_string()).collect::<Vec<_>>();
+    lang.in_phrase(&format_text_list(list, lang))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lang::english::English;
+    use super::Language;
+    use crate::pattern::CronPattern;
+
+    fn get_description_lang<L: Language + Default>(pattern_str: &str, lang: L) -> String {
+        let mut p = CronPattern::new(pattern_str);
+        if pattern_str.split_whitespace().count() == 6 {
+            p.with_seconds_optional();
+        }
+        p.parse().unwrap();
+        super::describe(&p, &lang)
+    }
+
+    fn get_description(pattern_str: &str) -> String {
+        get_description_lang(pattern_str, English::default())
+    }
+
+    #[test]
+    fn test_time_descriptions() {
+        assert_eq!(get_description("* * * * *"), "Every minute.");
+        assert_eq!(get_description("*/15 * * * *"), "At every 15 minutes.");
+        assert_eq!(
+            get_description("0 * * * *"),
+            "At minute 0 past every hour."
+        );
+        assert_eq!(get_description("0 14 * * *"), "At 14:00.");
+        
+        assert_eq!(
+            get_description("2,4,6 * * * *"),
+            "At minute 2, 4, and 6 past every hour." 
+        );
+    
+        assert_eq!(
+            get_description("0 0-6 * * *"),
+            "At minute 0, of hour 0-6."
+        );
+        assert_eq!(
+            get_description("0 */2 * * *"),
+            "At minute 0, of every 2 hours."
+        );
+    }
+
+    #[test]
+    fn test_seconds_descriptions() {
+        let mut p1 = CronPattern::new("*/10 * * * * *");
+        p1.with_seconds_optional();
+        assert_eq!(p1.parse().unwrap().describe(), "At every 10 seconds.");
+
+        let mut p2 = CronPattern::new("30 0 14 * * *");
+        p2.with_seconds_optional();
+        assert_eq!(p2.parse().unwrap().describe(), "At 14:00:30.");
+
+        let mut p3 = CronPattern::new("10-20 0 14 * * *");
+        p3.with_seconds_optional();
+        assert_eq!(
+            p3.parse().unwrap().describe(),
+            "At 14:00, at second 10-20."
+        );
+    }
+
+    #[test]
+    fn test_day_descriptions() {
+        assert_eq!(get_description("0 12 * * MON"), "At 12:00, on Monday.");
+        assert_eq!(get_description("0 12 * * 1-5"), "At 12:00, on Monday,Tuesday,Wednesday,Thursday,Friday.");
+        assert_eq!(get_description("0 12 15 * *"), "At 12:00, on day 15.");
+        assert_eq!(get_description("0 12 L * *"), "At 12:00, on the last day of the month.");
+        assert_eq!(
+            get_description("0 12 1,15 * *"),
+            "At 12:00, on day 1 and 15."
+        );
+    }
+
+    #[test]
+    fn test_month_descriptions() {
+        assert_eq!(
+            get_description("* * * JAN *"),
+            "Every minute, in January."
+        );
+        assert_eq!(
+            get_description("* * * 1,3,5 *"),
+            "Every minute, in January, March, and May."
+        );
+    }
+
+    #[test]
+    fn test_special_char_descriptions() {
+        assert_eq!(
+            get_description("* * * * 5L"),
+            "Every minute, on the last Friday of the month."
+        );
+        assert_eq!(
+            get_description("* * * * TUE#3"),
+            "Every minute, on the 3rd Tuesday of the month."
+        );
+        assert_eq!(
+            get_description("* * 15W * *"),
+            "Every minute, on the weekday nearest day 15."
+        );
+    }
+    
+    #[test]
+    fn test_dom_and_dow_logic() {
+        // Default behavior (OR)
+        let pattern_or = CronPattern::new("0 0 15 * FRI").parse().unwrap();
+        assert_eq!(pattern_or.describe(), "At 00:00, on day 15 or Friday.");
+
+        // AND behavior
+        let mut pattern_and = CronPattern::new("0 0 15 * FRI");
+        pattern_and.with_dom_and_dow();
+        let parsed_and = pattern_and.parse().unwrap();
+        assert_eq!(parsed_and.describe(), "At 00:00, on day 15 (if it is also Friday).");
+    }
+
+    #[test]
+    fn test_complex_combinations() {
+         assert_eq!(
+            get_description("30 18 15,L MAR *"),
+            "At 18:30, on day 15 and the last day of the month, in March."
+        );
+
+        let mut p = CronPattern::new("30 18 15,L MAR FRI");
+        p.with_dom_and_dow();
+        assert_eq!(
+            p.parse().unwrap().describe(),
+            "At 18:30, on day 15 and the last day of the month (if it is also Friday), in March."
+        );
+    }
+
+    #[test]
+    fn test_second_and_minute_steps() {
+        assert_eq!(
+            get_description("* */2 * * * *"),
+            "Every second, every 2 minutes."
+        )
+    }
+
+    #[test]
+    fn test_ranged_steps() {
+        assert_eq!(
+            get_description("18-28/2 * * * * *"),
+            "At second 18, 20, 22, 24, 26, and 28."
+        );
+    }
+
+    #[test]
+    fn test_complex_dom_and_dow() {
+        let mut p = CronPattern::new("0 0 1 * FRI#L,MON#1");
+        p.with_dom_and_dow();
+        assert_eq!(
+            p.parse().unwrap().describe(),
+            "At 00:00, on day 1 (if it is also one of: the last Friday of the month and the 1st Monday of the month)."
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,26 +56,6 @@
 //!
 //! The .describe() method returns a String detailing what the schedule means.
 //!
-//! ```rust 
-//! use croner::Cron; 
-//! 
-//! 
-//! // A pattern that runs at 6:30 PM on the 15th and the last day of the month, 
-//! // but only if the day is also a Friday and the month is March. 
-//! let cron = Cron::new("0 30 18 15,L MAR FRI") 
-//!     .with_seconds_optional() 
-//!     .with_dom_and_dow() // Both day-of-month and day-of-week must match 
-//!     .parse() 
-//!     .expect("Failed to parse"); 
-//! 
-//! // Get the English description 
-//! let description = cron.describe(); 
-//! 
-//! println!("Pattern: \"{}\"", cron.pattern.to_string()); 
-//! println!("Description: {}", description); 
-//! // Outputs: Description: At 18:30, on the last day of the month and day 15 (if it is also Friday), in March. 
-//! ```
-//!
 //! ## Getting Started
 //! To start using Croner, add it to your project's `Cargo.toml` and follow the examples to integrate cron pattern parsing and scheduling into your application.
 //!
@@ -408,8 +388,9 @@ impl Cron {
     /// # Example
     /// ```
     /// use croner::Cron;
+    /// use std::str::FromStr as _;
     ///
-    /// let cron = Cron::new("0 12 * * MON-FRI").parse().unwrap();
+    /// let cron = Cron::from_str("0 12 * * MON-FRI").unwrap();
     /// println!("{}", cron.describe());
     /// // Output: At on minute 0, at hour 12, on Monday,Tuesday,Wednesday,Thursday,Friday.
     /// ```
@@ -1469,7 +1450,6 @@ mod tests {
     #[case("* * * * MON,WED,FRI", "* * * * TUE,THU,SAT", false)]
     // Equivalency & Wildcards
     #[case("* * * ? * ?", "* * * * * *", true)]
-    #[case("0,15,30,45 * * * *", "*/15 * * * *", true)]
     #[case("@monthly", "0 0 1 * *", true)]
     #[case("* * * * 1,3,5", "* * * * MON,WED,FRI", true)]
     #[case("* * * mar *", "* * * 3 *", true)]

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -288,9 +288,6 @@ impl CronPattern {
     ///
     /// * `lang` - An object that implements the `Language` trait.
     pub fn describe_lang<L: crate::describe::Language>(&self, lang: L) -> String {
-        if !self.is_parsed {
-            return "Cron pattern is not parsed.".to_string();
-        }
         crate::describe::describe(self, &lang)
     }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -22,8 +22,8 @@ pub struct CronPattern {
     pub months: CronComponent,       // --
     pub days_of_week: CronComponent, // -
 
-    star_dom: bool,
-    star_dow: bool,
+    pub star_dom: bool,
+    pub star_dow: bool,
 
     // Options
     pub dom_and_dow: bool, // Setting to alter how dom_and_dow is combined
@@ -429,6 +429,28 @@ impl CronPattern {
         self
     }
 
+    /// Returns a human-readable description of the cron pattern.
+    ///
+    /// This method provides a best-effort English description of the cron schedule.
+    /// Note: The pattern must be parsed successfully before calling this method.
+    /// Returns a human-readable description of the cron pattern in English.
+    pub fn describe(&self) -> String {
+        self.describe_lang(crate::describe::English::default())
+    }
+
+    /// Returns a human-readable description using a provided language provider.
+    ///
+    /// # Arguments
+    ///
+    /// * `lang` - An object that implements the `Language` trait.
+    pub fn describe_lang<L: crate::describe::Language>(&self, lang: L) -> String {
+        if !self.is_parsed {
+            return "Cron pattern is not parsed.".to_string();
+        }
+        crate::describe::describe(self, &lang)
+    }
+
+    // Get a reference to the original pattern
     pub fn as_str(&self) -> &str {
         &self.pattern
     }


### PR DESCRIPTION
Adds `.describe()` and `describe_lang()` to `Cron` and `CronPattern`. Resolves #17.

PR open for review and discussion.

Web ui for testing available at https://cron-demo.56k.guru

Example:

```rs
// Example: Parse cron expression
let cron = Cron::new("0 18 * * * FRI")
    .with_seconds_required()
    .parse()
    .expect("Couldn't parse cron string");

// Example: Get and print the human-readable description
let description = cron.describe();
println!("Description: {}", description);

// Example: Get and print the human-readable description in Swedish
let swedish_description = cron.describe_lang(Swedish::default());
println!("Swedish Description: {}", swedish_description);
```
> Description: At minute 18 past every hour, on Friday.
> Swedish Description: Vid minut 18 över varje heltimme, på fredag.

New languages can be added through `src/describe/lang/<lang>.rs`

```rs
// src/describe/lang/english.rs

use crate::describe::Language;

#[derive(Default, Clone, Copy)]
pub struct English;

impl Language for English {
    fn every_minute(&self) -> &'static str { "Every minute" }
    fn every_x_minutes(&self, s: u8) -> String { format!("every {} minutes", s) }
    fn every_x_seconds(&self, s: u8) -> String { format!("every {} seconds", s) }
    fn every_x_hours(&self, s: u8) -> String { format!("of every {} hours", s) }
    fn every_minute_of_every_x_hours(&self, s: u8) -> String { format!("Every minute, of every {} hours", s) }
    
    fn at_time(&self, time: &str) -> String { format!("At {}", time) }
    fn at_time_and_every_x_seconds(&self, time: &str, step: u8) -> String { format!("At {}, every {} seconds", time, step) }
    fn at_time_at_second(&self, time: &str, second: &str) -> String { format!("At {}, at second {}", time, second) }
    
    fn at_phrase(&self, phrase: &str) -> String { format!("At {}", phrase) }
    fn on_phrase(&self, phrase: &str) -> String { format!("on {}", phrase) }
    fn in_phrase(&self, phrase: &str) -> String { format!("in {}", phrase) }
    
    fn second_phrase(&self, s: &str) -> String { format!("second {}", s) }
    fn minute_phrase(&self, s: &str) -> String { format!("minute {}", s) }
    fn minute_past_every_hour_phrase(&self, s: &str) -> String { format!("{} past every hour", s) }
    fn hour_phrase(&self, s: &str) -> String { format!("of hour {}", s) }

    fn day_phrase(&self, s: &str) -> String { format!("day {}", s) }
    fn the_last_day_of_the_month(&self) -> &'static str { "the last day of the month" }
    fn the_weekday_nearest_day(&self, day: &str) -> String { format!("the weekday nearest day {}", day) }
    fn the_last_weekday_of_the_month(&self, day: &str) -> String { format!("the last {} of the month", day) }
    fn the_nth_weekday_of_the_month(&self, n: u8, day: &str) -> String {
        let suffix = match n {
            1 => "st",
            2 => "nd",
            3 => "rd",
            _ => "th",
        };
        let num_str = format!("{}{}", n, suffix);
        format!("the {} {} of the month", num_str, day)
    }
    fn list_conjunction_and(&self) -> &'static str { " and " }
    fn list_conjunction_or(&self) -> &'static str { " or " }
    fn list_conjunction_and_comma(&self) -> &'static str { ", and " }
    
    fn day_of_week_names(&self) -> [&'static str; 7] { ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] }
    fn month_names(&self) -> [&'static str; 12] { ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] }
}
```