### PR TITLE
Only allow ? in dom and dow fields. Fix character validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ a few additions and changes as outlined below:
 ```
 
 - Croner expressions have the following additional modifiers:
-  - _?_: In the Rust version of croner, a questionmark behaves just as *, to
-    allow for legacy cron patterns to be used.
+  - _?_: In the Rust version of croner, a questionmark in the day-of-month or 
+    day-of-week field behaves just as *. This allow for legacy cron patterns 
+    to be used.
   - _L_: The letter 'L' can be used in the day of the month field to indicate
     the last day of the month. When used in the day of the week field in
     conjunction with the # character, it denotes the last specific weekday of
@@ -189,11 +190,11 @@ a few additions and changes as outlined below:
 
 | Field        | Required | Allowed values  | Allowed special characters | Remarks                                                                                                         |
 | ------------ | -------- | --------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Seconds      | Optional | 0-59            | * , - / ?                  |                                                                                                                 |
-| Minutes      | Yes      | 0-59            | * , - / ?                  |                                                                                                                 |
-| Hours        | Yes      | 0-23            | * , - / ?                  |                                                                                                                 |
+| Seconds      | Optional | 0-59            | * , - /                    |                                                                                                                 |
+| Minutes      | Yes      | 0-59            | * , - /                    |                                                                                                                 |
+| Hours        | Yes      | 0-23            | * , - /                    |                                                                                                                 |
 | Day of Month | Yes      | 1-31            | * , - / ? L W              |                                                                                                                 |
-| Month        | Yes      | 1-12 or JAN-DEC | * , - / ?                  |                                                                                                                 |
+| Month        | Yes      | 1-12 or JAN-DEC | * , - /                    |                                                                                                                 |
 | Day of Week  | Yes      | 0-7 or SUN-MON  | * , - / ? # L              | 0 to 6 are Sunday to Saturday<br>7 is Sunday, the same as 0<br># is used to specify nth occurrence of a weekday |
 
 > **Note** Weekday and month names are case-insensitive. Both `MON` and `mon`

--- a/src/component.rs
+++ b/src/component.rs
@@ -244,15 +244,12 @@ impl CronComponent {
                 self.handle_stepping(&parsed_part)?;
             } else if parsed_part.contains('-') {
                 self.handle_range(&parsed_part)?;
-            } else if parsed_part.contains('w') {
+            } else if parsed_part.contains('W') {
                 self.handle_closest_weekday(&parsed_part)?;
-            } else if parsed_part.eq_ignore_ascii_case("l") {
+            } else if parsed_part.eq_ignore_ascii_case("L") {
                 // Handle "L" for the last bit
                 self.enable_feature(LAST_BIT)?;
             } else {
-                // Replace 'l' with 'L'
-                parsed_part = parsed_part.replace('l', "L");
-
                 // If 'L' is contained without '#', like "5L", add the missing '#'
                 if parsed_part.ends_with('L') && !parsed_part.contains('#') {
                     parsed_part = parsed_part.replace('L', "#L");
@@ -281,7 +278,7 @@ impl CronComponent {
 
     fn get_nth_bit(value: &str) -> Result<u8, CronError> {
         // If value ends with 'L', we set the LAST_BIT and exit early
-        if value.ends_with('L') || value.ends_with('l') {
+        if value.ends_with('L') {
             return Ok(LAST_BIT);
         }
         if let Some(nth_pos) = value.find('#') {
@@ -316,7 +313,7 @@ impl CronComponent {
     }
 
     fn handle_closest_weekday(&mut self, value: &str) -> Result<(), CronError> {
-        if let Some(day_pos) = value.find('w') {
+        if let Some(day_pos) = value.find('W') {
             // Use a slice
             let day_str = &value[..day_pos];
 
@@ -335,7 +332,7 @@ impl CronComponent {
             // Set the bit for the closest weekday
             self.set_bit(day, CLOSEST_WEEKDAY_BIT)?;
         } else {
-            // If 'w' is not found, handle the value as a regular number
+            // If 'W' is not found, handle the value as a regular number
             self.handle_number(value)?;
         }
         Ok(())
@@ -557,7 +554,7 @@ mod tests {
     #[test]
     fn test_parse_closest_weekday() {
         let mut component = CronComponent::new(1, 31, CLOSEST_WEEKDAY_BIT, 0);
-        component.parse("15w").unwrap();
+        component.parse("15W").unwrap();
         assert!(component.is_bit_set(15, CLOSEST_WEEKDAY_BIT).unwrap());
         // You might want to add more tests for edge cases
     }


### PR DESCRIPTION
* Fixes bug where the library did not throw on illegal characters.
* Disallows `?` in fields where it is not relevant, to confirm with https://github.com/open-source-cron/ocps/blob/main/increments/OCPS-increment-1.4.md