### PR TITLE
Add reverse lookup feature

### DIFF
--- a/examples/iter_demo.rs
+++ b/examples/iter_demo.rs
@@ -14,7 +14,7 @@ fn main() {
     // (Or Local)
     // let time = Local::now();
 
-    // Get next 5 matches using iter_from
+    // Get next 5 matches using iter_after
     // There is also iter_after, which does not match starting time
     println!(
         "Finding matches of pattern '{}' starting from {}:",
@@ -22,7 +22,7 @@ fn main() {
         time
     );
 
-    for time in cron.iter_from(time).take(5) {
+    for time in cron.iter_after(time).take(5) {
         println!("{}", time);
     }
 }

--- a/examples/iter_demo.rs
+++ b/examples/iter_demo.rs
@@ -22,6 +22,6 @@ fn main() {
     );
 
     for time in cron.iter_after(time).take(5) {
-        println!("{}", time);
+        println!("{time}");
     }
 }

--- a/examples/simple_demo.rs
+++ b/examples/simple_demo.rs
@@ -31,7 +31,13 @@ fn main() {
 
     // Example: Iterator
     println!("Next 5 matches:");
-    for time in cron.clone().iter_from(Local::now()).take(5) {
+    for time in cron.clone().iter_after(Local::now()).take(5) {
+        println!("{}", time);
+    }
+
+    // Example: Reverse Iterator
+    println!("Previous 5 matches:");
+    for time in cron.clone().iter_before(Local::now()).take(5) {
         println!("{}", time);
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,22 +1,38 @@
-use crate::Cron;
-use chrono::{DateTime, Duration, TimeZone};
+use crate::{Cron, CronError, Direction};
+use chrono::{DateTime, TimeZone};
 
+/// An iterator over the occurrences of a cron schedule.
+/// It can iterate both forwards and backwards in time.
 pub struct CronIterator<Tz>
 where
     Tz: TimeZone,
 {
     cron: Cron,
     current_time: DateTime<Tz>,
+    is_first: bool,
+    inclusive: bool,
+    direction: Direction,
 }
 
 impl<Tz> CronIterator<Tz>
 where
     Tz: TimeZone,
 {
-    pub fn new(cron: Cron, start_time: DateTime<Tz>) -> Self {
+    /// Creates a new `CronIterator`.
+    ///
+    /// # Arguments
+    ///
+    /// * `cron` - The `Cron` schedule instance.
+    /// * `start_time` - The `DateTime` to start iterating from.
+    /// * `inclusive` - Whether the `start_time` should be included in the results if it matches.
+    /// * `direction` - The direction to iterate in (Forward or Backward).
+    pub fn new(cron: Cron, start_time: DateTime<Tz>, inclusive: bool, direction: Direction) -> Self {
         CronIterator {
             cron,
             current_time: start_time,
+            is_first: true,
+            inclusive,
+            direction,
         }
     }
 }
@@ -27,20 +43,33 @@ where
 {
     type Item = DateTime<Tz>;
 
+    /// Finds the next or previous occurrence of the cron schedule based on the iterator's direction.
     fn next(&mut self) -> Option<Self::Item> {
-        match self.cron.find_next_occurrence(&self.current_time, true) {
-            Ok(next_time) => {
-                // Check if we can add one second without overflow
-                let next_time_clone = next_time.clone();
-                if let Some(updated_time) = next_time.checked_add_signed(Duration::seconds(1)) {
-                    self.current_time = updated_time;
-                    Some(next_time_clone) // Return the next time
-                } else {
-                    // If we hit an overflow, stop the iteration
-                    None
-                }
+        // Determine if the search should be inclusive based on whether it's the first run.
+        let inclusive_search = if self.is_first {
+            self.is_first = false;
+            self.inclusive
+        } else {
+            false // Subsequent searches are always exclusive of the last found time.
+        };
+
+        let result = match self.direction {
+            Direction::Forward => self
+                .cron
+                .find_next_occurrence(&self.current_time, inclusive_search),
+            Direction::Backward => self
+                .cron
+                .find_previous_occurrence(&self.current_time, inclusive_search),
+        };
+
+        match result {
+            Ok(found_time) => {
+                // Update the current time to the found occurrence for the next iteration.
+                self.current_time = found_time.clone();
+                Some(found_time)
             }
-            Err(_) => None, // Stop the iteration if we cannot find the next occurrence
+            Err(CronError::TimeSearchLimitExceeded) => None, // Stop if we hit the year limit.
+            Err(_) => None, // Stop the iteration on any other error.
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ mod iterator;
 mod pattern;
 
 // Enum to specify the direction of time search, defined locally.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum Direction {
     Forward,
     Backward,
@@ -908,7 +908,7 @@ mod tests {
         ];
 
         // Iterate over the expected dates, checking each one
-        for (idx, current_date) in cron.clone().iter_from(start_date, Direction::Forward).take(5) {
+        for (idx, current_date) in cron.clone().iter_from(start_date, Direction::Forward).take(5).enumerate() {
             assert_eq!(expected_dates[idx], current_date);
         }
 
@@ -936,8 +936,7 @@ mod tests {
         ];
 
         // Iterate over the expected dates, checking each one
-        let mut idx = 0;
-        for current_date in cron.clone().iter_from(start_date, Direction::Forward).take(5) {
+        for (idx, current_date) in cron.clone().iter_from(start_date, Direction::Forward).take(5).enumerate() {
             assert_eq!(expected_dates[idx], current_date);
         }
 
@@ -1357,7 +1356,7 @@ mod tests {
     #[case("0,10,20 * * * *", "30,40,50 * * * *", false)]
     #[case("* * * * MON,WED,FRI", "* * * * TUE,THU,SAT", false)]
     // Equivalency & Wildcards
-    #[case("? ? ? ? ? ?", "* * * * * *", true)]
+    #[case("* * * ? * ?", "* * * * * *", true)]
     #[case("0,15,30,45 * * * *", "*/15 * * * *", true)]
     #[case("@monthly", "0 0 1 * *", true)]
     #[case("* * * * 1,3,5", "* * * * MON,WED,FRI", true)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,33 +4,43 @@
 //!
 //! ## Features
 //! - Parses a wide range of cron expressions, including extended formats.
-//! - Evaluates cron patterns to calculate upcoming execution times.
+//! - Evaluates cron patterns to calculate upcoming and previous execution times.
 //! - Supports time zone-aware scheduling.
 //! - Offers granularity up to seconds for precise task scheduling.
 //! - Compatible with the `chrono` library for dealing with date and time in Rust.
-//! 
+//!
 //! ## Crate Features
 //! - `serde`: Enables [`serde::Serialize`](https://docs.rs/serde/1/serde/trait.Serialize.html) and
 //!   [`serde::Deserialize`](https://docs.rs/serde/1/serde/trait.Deserialize.html) implementations for
 //!   [`Cron`](struct.Cron.html). This feature is disabled by default.
 //!
 //! ## Example
-//! The following example demonstrates how to use Croner to parse a cron expression and find the next occurrence of a specified time:
+//! The following example demonstrates how to use Croner to parse a cron expression and find the next and previous occurrences.
 //!
 //! ```rust
 //! use chrono::Utc;
 //! use croner::Cron;
 //!
-//! // Parse a cron expression to find the next occurrence at 00:00 on Friday
+//! // Parse a cron expression to find occurrences at 00:00 on Friday
 //! let cron = Cron::new("0 0 * * FRI").parse().expect("Successful parsing");
+//! let now = Utc::now();
 //!
-//! // Get the next occurrence from the current time, excluding the current time
-//! let next = cron.find_next_occurrence(&Utc::now(), false).unwrap();
+//! // Get the next occurrence from the current time
+//! let next = cron.find_next_occurrence(&now, false).unwrap();
+//!
+//! // Get the previous occurrence from the current time
+//! let previous = cron.find_previous_occurrence(&now, false).unwrap();
 //!
 //! println!(
 //!     "Pattern \"{}\" will match next at {}",
 //!     cron.pattern.to_string(),
 //!     next
+//! );
+//!
+//! println!(
+//!     "Pattern \"{}\" matched previously at {}",
+//!     cron.pattern.to_string(),
+//!     previous
 //! );
 //! ```
 //!
@@ -58,14 +68,14 @@
 //! // * * * * * *
 //! ```
 //!
-//! | Field        | Required | Allowed values  | Allowed special characters | Remarks                                                                                                         |
-//! | ------------ | -------- | --------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
-//! | Seconds      | Optional | 0-59            | * , - / ?                  |                                                                                                                 |
-//! | Minutes      | Yes      | 0-59            | * , - / ?                  |                                                                                                                 |
-//! | Hours        | Yes      | 0-23            | * , - / ?                  |                                                                                                                 |
-//! | Day of Month | Yes      | 1-31            | * , - / ? L W              |                                                                                                                 |
-//! | Month        | Yes      | 1-12 or JAN-DEC | * , - / ?                  |                                                                                                                 |
-//! | Day of Week  | Yes      | 0-7 or SUN-MON  | * , - / ? # L              | 0 to 6 are Sunday to Saturday, 7 is Sunday, the same as 0. '#' is used to specify the nth occurrence of a weekday |
+//! | Field        | Required | Allowed values    | Allowed special characters | Remarks                                                                                         |
+//! |--------------|----------|-------------------|----------------------------|-------------------------------------------------------------------------------------------------|
+//! | Seconds      | Optional | 0-59              | * , - / ?                  |                                                                                                 |
+//! | Minutes      | Yes      | 0-59              | * , - / ?                  |                                                                                                 |
+//! | Hours        | Yes      | 0-23              | * , - / ?                  |                                                                                                 |
+//! | Day of Month | Yes      | 1-31              | * , - / ? L W              |                                                                                                 |
+//! | Month        | Yes      | 1-12 or JAN-DEC   | * , - / ?                  |                                                                                                 |
+//! | Day of Week  | Yes      | 0-7 or SUN-MON    | * , - / ? # L              | 0 to 6 are Sunday to Saturday, 7 is Sunday, the same as 0. '#' is used to specify the nth weekday |
 //!
 //! For more information, refer to the full [README](https://github.com/hexagon/croner-rust).
 
@@ -75,13 +85,27 @@ mod component;
 mod iterator;
 mod pattern;
 
+// Enum to specify the direction of time search, defined locally.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Direction {
+    Forward,
+    Backward,
+}
+#[derive(PartialEq, Eq, Ord, PartialOrd, Hash, Clone, Copy, Debug)]
+pub enum TimeComponent {
+    Second = 1,
+    Minute,
+    Hour,
+    Day,
+    Month,
+}
 use errors::CronError;
 pub use iterator::CronIterator;
 use pattern::CronPattern;
 use std::str::FromStr;
 
 use chrono::{
-    DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Timelike,
+    DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, TimeZone, Timelike,
 };
 
 #[cfg(feature = "serde")]
@@ -93,22 +117,16 @@ use serde::{
 };
 
 const YEAR_UPPER_LIMIT: i32 = 5000;
+const YEAR_LOWER_LIMIT: i32 = 1970;
 
-enum TimeComponent {
-    Second = 1,
-    Minute,
-    Hour,
-    Day,
-    Month,
-    Year,
-}
 
 // The Cron struct represents a cron schedule and provides methods to parse cron strings,
-// check if a datetime matches the cron pattern, and find the next occurrence.
+// check if a datetime matches the cron pattern, and find the next/previous occurrence.
 #[derive(Debug, Clone)]
 pub struct Cron {
     pub pattern: CronPattern, // Parsed cron pattern
 }
+
 impl Cron {
     // Constructor to create a new instance of Cron with default settings
     pub fn new(cron_string: &str) -> Self {
@@ -123,7 +141,7 @@ impl Cron {
         Ok(self.clone())
     }
 
-    /// Evaluates if a given `DateTime` matches the cron pattern associated with this instance.
+    /// Evaluates if a given `DateTime` matches the cron pattern.
     ///
     /// The function checks each cron field (seconds, minutes, hours, day of month, month) against
     /// the provided `DateTime` to determine if it aligns with the cron pattern. Each field is
@@ -168,10 +186,7 @@ impl Cron {
     /// );
     /// ```
     pub fn is_time_matching<Tz: TimeZone>(&self, time: &DateTime<Tz>) -> Result<bool, CronError> {
-        // Convert to NaiveDateTime
         let naive_time = time.naive_local();
-
-        // Use NaiveDateTime for the comparisons
         Ok(self.pattern.second_match(naive_time.second())?
             && self.pattern.minute_match(naive_time.minute())?
             && self.pattern.hour_match(naive_time.hour())?
@@ -181,7 +196,7 @@ impl Cron {
             && self.pattern.month_match(naive_time.month())?)
     }
 
-    /// Finds the next occurrence of a scheduled date and time that matches the cron pattern,
+    /// Finds the next occurrence of a scheduled time that matches the cron pattern.
     /// starting from a given `start_time`. If `inclusive` is `true`, the search includes the
     /// `start_time`; otherwise, it starts from the next second.
     ///
@@ -234,38 +249,54 @@ impl Cron {
         &self,
         start_time: &DateTime<Tz>,
         inclusive: bool,
-    ) -> Result<DateTime<Tz>, CronError>
-    where
-        Tz: TimeZone,
-    {
+    ) -> Result<DateTime<Tz>, CronError> {
+        self.find_occurrence(start_time, inclusive, Direction::Forward)
+    }
+
+    /// Finds the previous occurrence of a scheduled time that matches the cron pattern.
+    pub fn find_previous_occurrence<Tz: TimeZone>(
+        &self,
+        start_time: &DateTime<Tz>,
+        inclusive: bool,
+    ) -> Result<DateTime<Tz>, CronError> {
+        self.find_occurrence(start_time, inclusive, Direction::Backward)
+    }
+
+    /// The main generic search function.
+    /// The main generic search function.
+    fn find_occurrence<Tz: TimeZone>(
+        &self,
+        start_time: &DateTime<Tz>,
+        inclusive: bool,
+        direction: Direction,
+    ) -> Result<DateTime<Tz>, CronError> {
         let mut naive_time = start_time.naive_local();
-        let originaltimezone = start_time.timezone();
+        let timezone = start_time.timezone();
 
         if !inclusive {
+            let adjustment = match direction {
+                Direction::Forward => Duration::seconds(1),
+                Direction::Backward => Duration::seconds(-1),
+            };
             naive_time = naive_time
-                .checked_add_signed(chrono::Duration::seconds(1))
+                .checked_add_signed(adjustment)
                 .ok_or(CronError::InvalidTime)?;
         }
 
         loop {
             let mut updated = false;
-
-            updated |= self.find_next_matching_month(&mut naive_time)?;
-            updated |= self.find_next_matching_day(&mut naive_time)?;
-            updated |= self.find_next_matching_hour(&mut naive_time)?;
-            updated |= self.find_next_matching_minute(&mut naive_time)?;
-            updated |= self.find_next_matching_second(&mut naive_time)?;
+            updated |= self.find_matching_date_component(&mut naive_time, direction, TimeComponent::Month)?;
+            updated |= self.find_matching_date_component(&mut naive_time, direction, TimeComponent::Day)?;
+            updated |= self.find_matching_granular_component(&mut naive_time, direction, TimeComponent::Hour)?;
+            updated |= self.find_matching_granular_component(&mut naive_time, direction, TimeComponent::Minute)?;
+            updated |= self.find_matching_granular_component(&mut naive_time, direction, TimeComponent::Second)?;
 
             if updated {
                 continue;
             }
 
-           // Convert back to original timezone
-           let (tz_datetime, was_adjusted) =
-                from_naive(naive_time, &originaltimezone)?;
+            let (tz_datetime, was_adjusted) = from_naive(naive_time, &timezone)?;
 
-            // If the time matches or we had to adjust due to a DST gap,
-            // accept tz_datetime as the next occurrence.
             if self.is_time_matching(&tz_datetime)? || was_adjusted {
                 return Ok(tz_datetime);
             } else {
@@ -276,179 +307,250 @@ impl Cron {
 
     /// Creates a `CronIterator` starting from the specified time.
     ///
-    /// This function will create an iterator that yields dates and times that
-    /// match a cron schedule, beginning at `start_from`. The iterator will
-    /// begin at the specified start time if it matches.
+    /// The search can be performed forwards or backwards in time.
     ///
-    /// # Examples
+    /// # Arguments
     ///
-    /// ```
-    /// use chrono::Utc;
-    /// use croner::Cron;
-    ///
-    /// // Parse cron expression
-    /// let cron = Cron::new("* * * * *").parse().expect("Couldn't parse cron string");
-    ///
-    /// // Compare to time now
-    /// let time = Utc::now();
-    ///
-    /// // Get next 5 matches using iter_from
-    /// println!("Finding matches of pattern '{}' starting from {}:", cron.pattern.to_string(), time);
-    ///
-    /// for time in cron.clone().iter_from(time).take(5) {
-    ///     println!("{}", time);
-    /// }
-    /// ```
-    ///
-    /// # Parameters
-    ///
-    /// - `start_from`: A `DateTime<Tz>` that represents the starting point for the iterator.
+    /// * `start_from` - A `DateTime<Tz>` that represents the starting point for the iterator.
+    /// * `direction` - A `Direction` to specify the search direction.
     ///
     /// # Returns
     ///
     /// Returns a `CronIterator<Tz>` that can be used to iterate over scheduled times.
-    pub fn iter_from<Tz>(&self, start_from: DateTime<Tz>) -> CronIterator<Tz>
-    where
-        Tz: TimeZone,
-    {
-        CronIterator::new(self.clone(), start_from)
+    pub fn iter_from<Tz: TimeZone>(
+        &self,
+        start_from: DateTime<Tz>,
+        direction: Direction,
+    ) -> CronIterator<Tz> {
+        CronIterator::new(
+            self.clone(),
+            start_from,
+            true,
+            direction,
+        )
     }
 
-    /// Creates a `CronIterator` starting after the specified time.
+    /// Creates a `CronIterator` starting after the specified time, in forward direction.
     ///
-    /// This function will create an iterator that yields dates and times that
-    /// match a cron schedule, beginning after `start_after`. The iterator will
-    /// not yield the specified start time; it will yield times that come
-    /// after it according to the cron schedule.
+    /// # Arguments
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use chrono::Utc;
-    /// use croner::Cron;
-    ///
-    /// // Parse cron expression
-    /// let cron = Cron::new("* * * * *").parse().expect("Couldn't parse cron string");
-    ///
-    /// // Compare to time now
-    /// let time = Utc::now();
-    ///
-    /// // Get next 5 matches using iter_from
-    /// println!("Finding matches of pattern '{}' starting from {}:", cron.pattern.to_string(), time);
-    ///
-    /// for time in cron.clone().iter_after(time).take(5) {
-    ///     println!("{}", time);
-    /// }
-    ///  
-    /// ```
-    ///
-    /// # Parameters
-    ///
-    /// - `start_after`: A `DateTime<Tz>` that represents the starting point for the iterator.
+    /// * `start_after` - A `DateTime<Tz>` that represents the starting point for the iterator.
     ///
     /// # Returns
     ///
     /// Returns a `CronIterator<Tz>` that can be used to iterate over scheduled times.
-    pub fn iter_after<Tz: TimeZone>(&self, start_after: DateTime<Tz>) -> CronIterator<Tz>
-    where
-        Tz: TimeZone,
-    {
-        let start_from = start_after
-            .checked_add_signed(Duration::seconds(1))
-            .expect("Invalid date encountered when adding one second");
-        CronIterator::new(self.clone(), start_from)
+    pub fn iter_after<Tz: TimeZone>(
+        &self,
+        start_after: DateTime<Tz>
+    ) -> CronIterator<Tz> {
+        CronIterator::new(
+            self.clone(),
+            start_after,
+            false,
+            Direction::Forward,
+        )
     }
 
-    // Internal functions to check for the next matching month/day/hour/minute/second and return the updated time.
-    fn find_next_matching_month(
+    /// Creates a `CronIterator` starting before the specified time, in backwards direction.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_before` - A `DateTime<Tz>` that represents the starting point for the iterator.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `CronIterator<Tz>` that can be used to iterate over scheduled times.
+    pub fn iter_before<Tz: TimeZone>(
+        &self,
+        start_before: DateTime<Tz>
+    ) -> CronIterator<Tz> {
+        CronIterator::new(
+            self.clone(),
+            start_before,
+            false,
+            Direction::Backward,
+        )
+    }
+
+    // TIME MANIPULATION FUNCTIONS
+
+    /// Sets a time component and resets lower-order ones based on direction.
+    fn set_time_component(
+        current_time: &mut NaiveDateTime,
+        component: TimeComponent,
+        value: u32,
+        direction: Direction,
+    ) -> Result<(), CronError> {
+        let mut new_time = *current_time;
+
+        new_time = match component {
+            TimeComponent::Second => new_time.with_second(value).ok_or(CronError::InvalidTime)?,
+            TimeComponent::Minute => new_time.with_minute(value).ok_or(CronError::InvalidTime)?,
+            TimeComponent::Hour => new_time.with_hour(value).ok_or(CronError::InvalidTime)?,
+            _ => return Err(CronError::InvalidTime),
+        };
+
+        match direction {
+            Direction::Forward => {
+                if component >= TimeComponent::Hour {
+                    new_time = new_time.with_minute(0).unwrap();
+                }
+                if component >= TimeComponent::Minute {
+                    new_time = new_time.with_second(0).unwrap();
+                }
+            }
+            Direction::Backward => {
+                if component >= TimeComponent::Hour {
+                    new_time = new_time.with_minute(59).unwrap();
+                }
+                if component >= TimeComponent::Minute {
+                    new_time = new_time.with_second(59).unwrap();
+                }
+            }
+        }
+
+        *current_time = new_time;
+        Ok(())
+    }
+
+    /// Adjusts a time component up or down, resetting lower-order ones.
+    fn adjust_time_component(
+        current_time: &mut NaiveDateTime,
+        component: TimeComponent,
+        direction: Direction,
+    ) -> Result<(), CronError> {
+        let limit = match direction {
+            Direction::Forward => YEAR_UPPER_LIMIT,
+            Direction::Backward => YEAR_LOWER_LIMIT,
+        };
+
+        if current_time.year() == limit {
+            return Err(CronError::TimeSearchLimitExceeded);
+        }
+
+        match direction {
+            Direction::Forward => {
+                let duration = match component {
+                    TimeComponent::Minute => Duration::minutes(1),
+                    TimeComponent::Hour => Duration::hours(1),
+                    TimeComponent::Day => Duration::days(1),
+                    TimeComponent::Month => {
+                        let mut year = current_time.year();
+                        let mut month = current_time.month() + 1;
+                        if month > 12 {
+                            year += 1;
+                            month = 1;
+                        }
+                        *current_time = NaiveDate::from_ymd_opt(year, month, 1)
+                            .ok_or(CronError::InvalidDate)?
+                            .and_hms_opt(0, 0, 0)
+                            .ok_or(CronError::InvalidTime)?;
+                        return Ok(());
+                    }
+                    _ => return Err(CronError::InvalidTime),
+                };
+                *current_time = current_time
+                    .checked_add_signed(duration)
+                    .ok_or(CronError::InvalidTime)?;
+                if component >= TimeComponent::Day {
+                    *current_time = current_time.with_hour(0).unwrap();
+                }
+                if component >= TimeComponent::Hour {
+                    *current_time = current_time.with_minute(0).unwrap();
+                }
+                if component >= TimeComponent::Minute {
+                    *current_time = current_time.with_second(0).unwrap();
+                }
+            }
+            Direction::Backward => {
+                let duration = match component {
+                    TimeComponent::Minute => Duration::minutes(1),
+                    TimeComponent::Hour => Duration::hours(1),
+                    TimeComponent::Day => Duration::days(1),
+                    TimeComponent::Month => {
+                        let next_month_first_day = NaiveDate::from_ymd_opt(
+                            current_time.year(),
+                            current_time.month(),
+                            1,
+                        )
+                        .ok_or(CronError::InvalidDate)?;
+                        *current_time = (next_month_first_day - Duration::days(1))
+                            .and_hms_opt(23, 59, 59)
+                            .ok_or(CronError::InvalidTime)?;
+                        return Ok(());
+                    }
+                    _ => return Err(CronError::InvalidTime),
+                };
+                *current_time = current_time
+                    .checked_sub_signed(duration)
+                    .ok_or(CronError::InvalidTime)?;
+                if component >= TimeComponent::Day {
+                    *current_time = current_time.with_hour(23).unwrap();
+                }
+                if component >= TimeComponent::Hour {
+                    *current_time = current_time.with_minute(59).unwrap();
+                }
+                if component >= TimeComponent::Minute {
+                    *current_time = current_time.with_second(59).unwrap();
+                }
+            }
+        }
+        Ok(())
+    }
+    fn find_matching_date_component(
         &self,
         current_time: &mut NaiveDateTime,
+        direction: Direction,
+        component: TimeComponent,
     ) -> Result<bool, CronError> {
-        let mut incremented = false;
-        while !self.pattern.month_match(current_time.month())? {
-            increment_time_component(current_time, TimeComponent::Month)?;
-            incremented = true;
+        let mut changed = false;
+        // Loop until the component matches the pattern
+        while !(match component {
+            TimeComponent::Month => self.pattern.month_match(current_time.month()),
+            TimeComponent::Day => self.pattern.day_match(
+                current_time.year(),
+                current_time.month(),
+                current_time.day(),
+            ),
+            _ => Ok(true), // Should not happen for other components, but this is safe
+        })? {
+            Self::adjust_time_component(current_time, component, direction)?;
+            changed = true;
         }
-        Ok(incremented)
+        Ok(changed)
     }
 
-    fn find_next_matching_day(&self, current_time: &mut NaiveDateTime) -> Result<bool, CronError> {
-        let mut incremented = false;
-        while !self.pattern.day_match(
-            current_time.year(),
-            current_time.month(),
-            current_time.day(),
-        )? {
-            increment_time_component(current_time, TimeComponent::Day)?;
-            incremented = true;
-        }
-
-        Ok(incremented)
-    }
-
-    fn find_next_matching_hour(&self, current_time: &mut NaiveDateTime) -> Result<bool, CronError> {
-        let mut incremented = false;
-        let next_hour_result = self.pattern.next_hour_match(current_time.hour());
-
-        match next_hour_result {
-            Ok(Some(next_match)) if next_match != current_time.hour() => {
-                set_time_component(current_time, TimeComponent::Hour, next_match)?;
-            }
-            Ok(None) => {
-                increment_time_component(current_time, TimeComponent::Day)?;
-                incremented = true;
-            }
-            Err(e) => return Err(e), // Propagate any CronError
-            _ => {}                  // No action needed if the current hour already matches
-        }
-        Ok(incremented)
-    }
-
-    fn find_next_matching_minute(
+    /// Consolidated helper for time-based components (Hour, Minute, Second).
+    fn find_matching_granular_component(
         &self,
         current_time: &mut NaiveDateTime,
+        direction: Direction,
+        component: TimeComponent,
     ) -> Result<bool, CronError> {
-        let mut incremented = false;
-        let next_minute_result = self.pattern.next_minute_match(current_time.minute());
+        let mut changed = false;
+        let (current_value, next_larger_component) = match component {
+            TimeComponent::Hour => (current_time.hour(), TimeComponent::Day),
+            TimeComponent::Minute => (current_time.minute(), TimeComponent::Hour),
+            TimeComponent::Second => (current_time.second(), TimeComponent::Minute),
+            _ => return Err(CronError::InvalidTime),
+        };
 
-        match next_minute_result {
-            Ok(Some(next_match)) if next_match != current_time.minute() => {
-                incremented = true;
-                set_time_component(current_time, TimeComponent::Minute, next_match)?;
-            }
-            Ok(None) => {
-                incremented = true;
-                increment_time_component(current_time, TimeComponent::Hour)?;
-            }
-            Err(e) => return Err(e), // Propagate the CronError
-            _ => {}                  // No action needed if the current minute matches
-        }
-        Ok(incremented)
-    }
+        let match_result = self
+            .pattern
+            .find_match_in_component(current_value, component, direction)?;
 
-    fn find_next_matching_second(
-        &self,
-        current_time: &mut NaiveDateTime,
-    ) -> Result<bool, CronError> {
-        let mut incremented = false;
-        let next_second_result = self.pattern.next_second_match(current_time.second());
-
-        match next_second_result {
-            Ok(Some(next_match)) => {
-                // If a matching second is found, set it and mark as incremented.
-                set_time_component(current_time, TimeComponent::Second, next_match)?;
+        match match_result {
+            Some(match_value) => {
+                if match_value != current_value {
+                    Self::set_time_component(current_time, component, match_value, direction)?;
+                }
             }
-            Ok(None) => {
-                // If no match is found in the current minute, increment the minute.
-                increment_time_component(current_time, TimeComponent::Minute)?;
-                incremented = true;
-            }
-            Err(e) => {
-                // Propagate any errors encountered during the match process.
-                return Err(e);
+            None => {
+                Self::adjust_time_component(current_time, next_larger_component, direction)?;
+                changed = true;
             }
         }
-        Ok(incremented)
+        Ok(changed)
     }
 
     pub fn with_dom_and_dow(&mut self) -> &mut Self {
@@ -487,8 +589,7 @@ impl FromStr for Cron {
     type Err = CronError;
 
     fn from_str(cron_string: &str) -> Result<Cron, CronError> {
-        let res = Cron::new(cron_string);
-        Ok(res)
+        Cron::new(cron_string).parse()
     }
 }
 
@@ -529,185 +630,25 @@ impl<'de> Deserialize<'de> for Cron {
     }
 }
 
-// Recursive function to handle setting the time and managing overflows.
-#[allow(clippy::too_many_arguments)]
-fn set_time(
-    current_time: &mut NaiveDateTime,
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    minute: u32,
-    second: u32,
-    component: TimeComponent,
-) -> Result<(), CronError> {
-    // First, try creating a NaiveDate and NaiveTime
-    match (
-        NaiveDate::from_ymd_opt(year, month, day),
-        NaiveTime::from_hms_opt(hour, minute, second),
-    ) {
-        (Some(date), Some(time)) => {
-            // Combine date and time into NaiveDateTime
-            *current_time = date.and_time(time);
-            Ok(())
-        }
-        _ => {
-            // Handle invalid date or overflow by incrementing the next higher component.
-            match component {
-                TimeComponent::Second => set_time(
-                    current_time,
-                    year,
-                    month,
-                    day,
-                    hour,
-                    minute + 1,
-                    0,
-                    TimeComponent::Minute,
-                ),
-                TimeComponent::Minute => set_time(
-                    current_time,
-                    year,
-                    month,
-                    day,
-                    hour + 1,
-                    0,
-                    0,
-                    TimeComponent::Hour,
-                ),
-                TimeComponent::Hour => set_time(
-                    current_time,
-                    year,
-                    month,
-                    day + 1,
-                    0,
-                    0,
-                    0,
-                    TimeComponent::Day,
-                ),
-                TimeComponent::Day => set_time(
-                    current_time,
-                    year,
-                    month + 1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    TimeComponent::Month,
-                ),
-                TimeComponent::Month => {
-                    set_time(current_time, year + 1, 1, 1, 0, 0, 0, TimeComponent::Year)
+
+// Convert `NaiveDateTime` back to `DateTime<Tz>`
+pub fn from_naive<Tz: TimeZone>(
+    naive_time: NaiveDateTime,
+    timezone: &Tz,
+) -> Result<(DateTime<Tz>, bool), CronError> {
+    match timezone.from_local_datetime(&naive_time) {
+        chrono::LocalResult::Single(dt) => Ok((dt, false)),
+        chrono::LocalResult::Ambiguous(dt1, _) => Ok((dt1, false)),
+        chrono::LocalResult::None => {
+            // Handle DST gap by searching nearby
+            for i in 0..3600 {
+                let adjusted = naive_time + Duration::seconds(i + 1);
+                if let chrono::LocalResult::Single(dt) = timezone.from_local_datetime(&adjusted) {
+                    return Ok((dt, true));
                 }
-                TimeComponent::Year => Err(CronError::InvalidDate),
             }
+            Err(CronError::InvalidTime)
         }
-    }
-}
-
-fn set_time_component(
-    current_time: &mut NaiveDateTime,
-    component: TimeComponent,
-    set_to: u32,
-) -> Result<(), CronError> {
-    // Extract all parts
-    let (year, month, day, hour, minute, _second) = (
-        current_time.year(),
-        current_time.month(),
-        current_time.day(),
-        current_time.hour(),
-        current_time.minute(),
-        current_time.second(),
-    );
-
-    match component {
-        TimeComponent::Year => set_time(current_time, set_to as i32, 0, 0, 0, 0, 0, component),
-        TimeComponent::Month => set_time(current_time, year, set_to, 0, 0, 0, 0, component),
-        TimeComponent::Day => set_time(current_time, year, month, set_to, 0, 0, 0, component),
-        TimeComponent::Hour => set_time(current_time, year, month, day, set_to, 0, 0, component),
-        TimeComponent::Minute => {
-            set_time(current_time, year, month, day, hour, set_to, 0, component)
-        }
-        TimeComponent::Second => set_time(
-            current_time,
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            set_to,
-            component,
-        ),
-    }
-}
-
-    // Convert `NaiveDateTime` back to `DateTime<Tz>`
-    pub fn from_naive<Tz: TimeZone>(
-        naive_time: NaiveDateTime,
-        timezone: &Tz,
-    ) -> Result<(DateTime<Tz>, bool), CronError> {
-        match timezone.from_local_datetime(&naive_time) {
-            chrono::LocalResult::Single(dt) => Ok((dt, false)), // No adjustment needed
-            chrono::LocalResult::Ambiguous(dt1, _dt2) => Ok((dt1, false)), // No adjustment for ambiguity (still original time)
-            chrono::LocalResult::None => {
-                // The naive time is invalid (e.g. DST gap).
-                // Try incrementing until valid.
-                for i in 0..3600 {
-                    let adjusted = naive_time + Duration::seconds(i + 1); // Start with +1 second
-                    match timezone.from_local_datetime(&adjusted) {
-                        chrono::LocalResult::Single(dt) => return Ok((dt, true)), // Found a valid time after adjustment
-                        chrono::LocalResult::Ambiguous(dt1, _dt2) => return Ok((dt1, true)), // Found an ambiguous time after adjustment
-                        chrono::LocalResult::None => continue, // Still in the gap, continue searching
-                    }
-                }
-                Err(CronError::InvalidTime) // No valid time found within 3600 seconds
-            }
-        }
-    }
-
-fn increment_time_component(
-    current_time: &mut NaiveDateTime,
-    component: TimeComponent,
-) -> Result<(), CronError> {
-    // Check for time overflow
-    if current_time.year() >= YEAR_UPPER_LIMIT {
-        return Err(CronError::TimeSearchLimitExceeded);
-    }
-
-    // Extract all parts
-    let (year, month, day, hour, minute, second) = (
-        current_time.year(),
-        current_time.month(),
-        current_time.day(),
-        current_time.hour(),
-        current_time.minute(),
-        current_time.second(),
-    );
-
-    // Increment the component and try to set the new time.
-    match component {
-        TimeComponent::Year => set_time(current_time, year + 1, 1, 1, 0, 0, 0, component),
-        TimeComponent::Month => set_time(current_time, year, month + 1, 1, 0, 0, 0, component),
-        TimeComponent::Day => set_time(current_time, year, month, day + 1, 0, 0, 0, component),
-        TimeComponent::Hour => set_time(current_time, year, month, day, hour + 1, 0, 0, component),
-        TimeComponent::Minute => set_time(
-            current_time,
-            year,
-            month,
-            day,
-            hour,
-            minute + 1,
-            0,
-            component,
-        ),
-        TimeComponent::Second => set_time(
-            current_time,
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second + 1,
-            component,
-        ),
     }
 }
 
@@ -967,7 +908,7 @@ mod tests {
 
         // Iterate over the expected dates, checking each one
         let mut idx = 0;
-        for current_date in cron.clone().iter_from(start_date).take(5) {
+        for current_date in cron.clone().iter_from(start_date, Direction::Forward).take(5) {
             assert_eq!(expected_dates[idx], current_date);
             idx = idx + 1;
         }
@@ -997,7 +938,7 @@ mod tests {
 
         // Iterate over the expected dates, checking each one
         let mut idx = 0;
-        for current_date in cron.clone().iter_from(start_date).take(5) {
+        for current_date in cron.clone().iter_from(start_date, Direction::Forward).take(5) {
             assert_eq!(expected_dates[idx], current_date);
             idx = idx + 1;
         }
@@ -1198,7 +1139,7 @@ mod tests {
 
         // Iterate over the expected dates, checking each one
         let mut idx = 0;
-        for current_date in cron.iter_from(start_date).take(expected_dates.len()) {
+        for current_date in cron.iter_from(start_date, Direction::Forward).take(expected_dates.len()) {
             assert_eq!(expected_dates[idx], current_date);
             idx += 1;
         }
@@ -1232,7 +1173,7 @@ mod tests {
 
         // Iterate over the expected dates, checking each one
         let mut idx = 0;
-        for current_date in cron.iter_from(start_date).take(expected_dates.len()) {
+        for current_date in cron.iter_from(start_date, Direction::Forward).take(expected_dates.len()) {
             assert_eq!(expected_dates[idx], current_date);
             idx += 1;
         }
@@ -1266,7 +1207,7 @@ mod tests {
 
         // Iterate over the expected dates, checking each one
         let mut idx = 0;
-        for current_date in cron.iter_from(start_date).take(5) {
+        for current_date in cron.iter_from(start_date, Direction::Forward).take(5) {
             assert_eq!(expected_dates[idx], current_date);
             idx += 1;
         }
@@ -1297,7 +1238,7 @@ mod tests {
 
         // Iterate over the expected dates, checking each one
         let mut idx = 0;
-        for current_date in cron.iter_from(start_date).take(5) {
+        for current_date in cron.iter_from(start_date, Direction::Forward).take(5) {
             assert_eq!(expected_dates[idx], current_date);
             idx += 1;
         }
@@ -1407,5 +1348,39 @@ mod tests {
             &[Token::Str("Invalid cron pattern")],
             "Invalid pattern: Pattern must consist of five or six fields (minute, hour, day, month, day of week, and optional second)."
         );
+    }
+
+    #[test]
+    fn test_find_previous_occurrence() -> Result<(), CronError> {
+        let cron = Cron::new("* * * * *").parse()?;
+        let start_time = Local.with_ymd_and_hms(2023, 1, 1, 0, 1, 30).unwrap();
+        let prev_occurrence = cron.find_previous_occurrence(&start_time, false)?;
+        let expected_time = Local.with_ymd_and_hms(2023, 1, 1, 0, 1, 0).unwrap();
+        assert_eq!(prev_occurrence, expected_time);
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_previous_occurrence_inclusive() -> Result<(), CronError> {
+        let cron = Cron::new("* * * * *").parse()?;
+        let start_time = Local.with_ymd_and_hms(2023, 1, 1, 0, 1, 0).unwrap();
+        let prev_occurrence = cron.find_previous_occurrence(&start_time, true)?;
+        assert_eq!(prev_occurrence, start_time);
+        Ok(())
+    }
+
+    #[test]
+    fn test_wrap_year_backwards() -> Result<(), CronError> {
+        let cron = Cron::new("0 0 1 1 *").parse()?; // Jan 1st, 00:00
+        let start_time = Local.with_ymd_and_hms(2024, 1, 1, 0, 0, 1).unwrap();
+        let prev_occurrence = cron.find_previous_occurrence(&start_time, false)?;
+        let expected_time = Local.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(prev_occurrence, expected_time);
+
+        let start_time_2 = Local.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let prev_occurrence_2 = cron.find_previous_occurrence(&start_time_2, false)?;
+        let expected_time_2 = Local.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(prev_occurrence_2, expected_time_2);
+        Ok(())
     }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -227,8 +227,7 @@ impl CronPattern {
                 ("WED", "4"), ("THU", "5"), ("FRI", "6"), ("SAT", "7"),
             ]
         };
-        let mut replaced = pattern.trim().to_lowercase();
-
+        let mut replaced = pattern.to_string();
 
         // Replace nicknames with their numeric values
         for &(nickname, value) in &nicknames {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -3,6 +3,7 @@ use crate::component::{
     NTH_3RD_BIT, NTH_4TH_BIT, NTH_5TH_BIT, NTH_ALL,
 };
 use crate::errors::CronError;
+use crate::{Direction, TimeComponent};
 use chrono::{Datelike, Duration, NaiveDate, Weekday};
 
 // This struct is used for representing and validating cron pattern strings.
@@ -57,7 +58,6 @@ impl CronPattern {
     }
 
     // Parses the cron pattern string into its respective fields.
-    // Handles optional seconds field, named shortcuts, and determines if 'L' flag is used for last day of the month.
     pub fn parse(&mut self) -> Result<CronPattern, CronError> {
         if self.pattern.trim().is_empty() {
             return Err(CronError::EmptyPattern);
@@ -101,11 +101,8 @@ impl CronPattern {
 
         // Default seconds to "0" if omitted
         if parts.len() == 5 {
-            parts.insert(0, "0"); // prepend "0" if the seconds part is missing
-
-            // Error it there is an extra part and seconds are not allowed
+            parts.insert(0, "0");
         }
-
         // Handle star-dom and star-dow
         self.star_dom = parts[3].trim() == "*";
         self.star_dow = parts[5].trim() == "*";
@@ -118,7 +115,7 @@ impl CronPattern {
         self.months.parse(parts[4])?;
         self.days_of_week.parse(parts[5])?;
 
-        // Handle conversion of 7 to 0 for day_of_week if necessary
+                // Handle conversion of 7 to 0 for day_of_week if necessary
         // this has to be done last because range could be 6-7 (sat-sun)
         if !self.with_alternative_weekdays {
             for nth_bit in [
@@ -136,10 +133,10 @@ impl CronPattern {
             }
         }
 
-        // Success!
         self.is_parsed = true;
         Ok(self.clone())
     }
+
 
     // Validates that the cron pattern only contains legal characters for each field.
     // - ? is replaced with * before parsing, so it does not need to be included
@@ -181,8 +178,6 @@ impl CronPattern {
     // Converts named cron pattern shortcuts like '@daily' into their equivalent standard cron pattern.
     fn handle_nicknames(pattern: &str, with_seconds_required: bool) -> String {
         let pattern = pattern.trim();
-
-        // Closure for case-insensitive comparison
         let eq_ignore_case = |a: &str, b: &str| a.eq_ignore_ascii_case(b);
 
         let base_pattern = match pattern {
@@ -203,31 +198,17 @@ impl CronPattern {
 
     // Converts day-of-week nicknames into their equivalent standard cron pattern.
     fn replace_alpha_weekdays(pattern: &str, alternative_weekdays: bool) -> String {
-        // Day-of-week nicknames to their numeric values.
         let nicknames = if !alternative_weekdays {
             [
-                ("-sun", "-7"), // Use 7 for upper range sunday
-                ("sun", "0"),
-                ("mon", "1"),
-                ("tue", "2"),
-                ("wed", "3"),
-                ("thu", "4"),
-                ("fri", "5"),
-                ("sat", "6"),
+                ("-sun", "-7"), ("sun", "0"), ("mon", "1"), ("tue", "2"),
+                ("wed", "3"), ("thu", "4"), ("fri", "5"), ("sat", "6"),
             ]
         } else {
             [
-                ("-sun", "-1"),
-                ("sun", "1"),
-                ("mon", "2"),
-                ("tue", "3"),
-                ("wed", "4"),
-                ("thu", "5"),
-                ("fri", "6"),
-                ("sat", "7"),
+                ("-sun", "-1"), ("sun", "1"), ("mon", "2"), ("tue", "3"),
+                ("wed", "4"), ("thu", "5"), ("fri", "6"), ("sat", "7"),
             ]
         };
-
         let mut replaced = pattern.trim().to_lowercase();
 
         // Replace nicknames with their numeric values
@@ -240,20 +221,10 @@ impl CronPattern {
 
     // Converts month nicknames into their equivalent standard cron pattern.
     fn replace_alpha_months(pattern: &str) -> String {
-        // Day-of-week nicknames to their numeric values.
         let nicknames = [
-            ("jan", "1"),
-            ("feb", "2"),
-            ("mar", "3"),
-            ("apr", "4"),
-            ("may", "5"),
-            ("jun", "6"),
-            ("jul", "7"),
-            ("aug", "8"),
-            ("sep", "9"),
-            ("oct", "10"),
-            ("nov", "11"),
-            ("dec", "12"),
+            ("jan", "1"), ("feb", "2"), ("mar", "3"), ("apr", "4"),
+            ("may", "5"), ("jun", "6"), ("jul", "7"), ("aug", "8"),
+            ("sep", "9"), ("oct", "10"), ("nov", "11"), ("dec", "12"),
         ];
 
         let mut replaced = pattern.trim().to_lowercase();
@@ -266,12 +237,10 @@ impl CronPattern {
         replaced
     }
 
-    // Additional method needed to determine the nth weekday of the month
+    // Determines the nth weekday of the month
     fn is_nth_weekday_of_month(date: chrono::NaiveDate, nth: u8, weekday: Weekday) -> bool {
         let mut count = 0;
-        let mut current = date
-            .with_day(1)
-            .expect("Invalid date encountered while setting to first of the month");
+        let mut current = date.with_day(1).unwrap();
         while current.month() == date.month() {
             if current.weekday() == weekday {
                 count += 1;
@@ -284,80 +253,51 @@ impl CronPattern {
         false
     }
 
-    // This method checks if a given year, month, and day match the day part of the cron pattern.
+    // Checks if a given year, month, and day match the day part of the cron pattern.
     pub fn day_match(&self, year: i32, month: u32, day: u32) -> Result<bool, CronError> {
-        // First, check if the day is within the valid range
         if day == 0 || day > 31 || month == 0 || month > 12 {
             return Err(CronError::InvalidDate);
         }
 
-        // Convert year, month, and day into a date object to work with
-        let date =
-            chrono::NaiveDate::from_ymd_opt(year, month, day).ok_or(CronError::InvalidDate)?;
-
+        let date = NaiveDate::from_ymd_opt(year, month, day).ok_or(CronError::InvalidDate)?;
         let mut day_matches = self.days.is_bit_set(day as u8, ALL_BIT)?;
         let mut dow_matches = false;
 
-        // If the 'L' flag is used, we need to check if the given day is the last day of the month
         if !day_matches && self.days.is_feature_enabled(LAST_BIT) {
-            let last_day = CronPattern::last_day_of_month(year, month)?;
-            if !day_matches && day == last_day {
+            if day == Self::last_day_of_month(year, month)? {
                 day_matches = true;
             }
         }
 
-        // Make an extra check if any adjacent day is matching through the closest-weekday flag
         if !day_matches && self.closest_weekday(year, month, day)? {
             day_matches = true;
         }
 
-        // Check for nth weekday of the month flags
         for nth in 1..=5 {
             let nth_bit = match nth {
-                1 => NTH_1ST_BIT,
-                2 => NTH_2ND_BIT,
-                3 => NTH_3RD_BIT,
-                4 => NTH_4TH_BIT,
-                5 => NTH_5TH_BIT,
-                _ => continue, // We have already validated that nth is between 1 and 5
+                1 => NTH_1ST_BIT, 2 => NTH_2ND_BIT, 3 => NTH_3RD_BIT,
+                4 => NTH_4TH_BIT, 5 => NTH_5TH_BIT, _ => continue,
             };
-            if self
-                .days_of_week
-                .is_bit_set(date.weekday().num_days_from_sunday() as u8, nth_bit)?
-                && CronPattern::is_nth_weekday_of_month(date, nth, date.weekday())
+            if self.days_of_week.is_bit_set(date.weekday().num_days_from_sunday() as u8, nth_bit)?
+                && Self::is_nth_weekday_of_month(date, nth, date.weekday())
             {
                 dow_matches = true;
                 break;
             }
         }
 
-        // If the 'L' flag is used for the day of the week, check if it's the last one of the month
-        if !dow_matches
-            && self
-                .days_of_week
-                .is_bit_set(date.weekday().num_days_from_sunday() as u8, LAST_BIT)?
-        {
-            let next_weekday = date + chrono::Duration::days(7);
-            if !dow_matches && next_weekday.month() != date.month() {
-                // If adding 7 days changes the month, then it is the last occurrence of the day of the week
+        if !dow_matches && self.days_of_week.is_bit_set(date.weekday().num_days_from_sunday() as u8, LAST_BIT)? {
+            if (date + chrono::Duration::days(7)).month() != date.month() {
                 dow_matches = true;
             }
         }
 
-        // Check if the specific day of the week is set in the bitset
-        // Note: In chrono, Sunday is 0, Monday is 1, and so on...
-        let day_of_week = date.weekday().num_days_from_sunday() as u8; // Adjust as necessary for your bitset
-        dow_matches = dow_matches || self.days_of_week.is_bit_set(day_of_week, ALL_BIT)?;
+        dow_matches = dow_matches || self.days_of_week.is_bit_set(date.weekday().num_days_from_sunday() as u8, ALL_BIT)?;
 
-        // The day matches if it's set in the days bitset or the days of the week bitset
         if (day_matches && self.star_dow) || (dow_matches && self.star_dom) {
             Ok(true)
         } else if !self.star_dom && !self.star_dow {
-            if !self.dom_and_dow {
-                Ok(day_matches || dow_matches)
-            } else {
-                Ok(day_matches && dow_matches)
-            }
+            if !self.dom_and_dow { Ok(day_matches || dow_matches) } else { Ok(day_matches && dow_matches) }
         } else {
             Ok(false)
         }
@@ -365,156 +305,112 @@ impl CronPattern {
 
     // Helper function to find the last day of a given month
     fn last_day_of_month(year: i32, month: u32) -> Result<u32, CronError> {
-        if month == 0 || month > 12 {
-            return Err(CronError::InvalidDate);
-        }
-
-        // Create a date that should be the first day of the next month
-        let next_month_year = if month == 12 { year + 1 } else { year };
-        let next_month = if month == 12 { 1 } else { month + 1 };
-
-        let next_month_date = NaiveDate::from_ymd_opt(next_month_year, next_month, 1)
-            .ok_or(CronError::InvalidDate)?;
-
-        // Subtract one day to get the last day of the given month
-        let last_day_date = next_month_date
-            .checked_sub_signed(Duration::days(1))
-            .ok_or(CronError::InvalidDate)?;
-
-        // Return only the day
-        Ok(last_day_date.day())
+        if !(1..=12).contains(&month) { return Err(CronError::InvalidDate); }
+        let (y, m) = if month == 12 { (year + 1, 1) } else { (year, month + 1) };
+        Ok(NaiveDate::from_ymd_opt(y, m, 1).unwrap().pred_opt().unwrap().day())
     }
 
     pub fn closest_weekday(&self, year: i32, month: u32, day: u32) -> Result<bool, CronError> {
-        let candidate_date =
-            NaiveDate::from_ymd_opt(year, month, day).ok_or(CronError::InvalidDate)?;
+        let candidate_date = NaiveDate::from_ymd_opt(year, month, day).ok_or(CronError::InvalidDate)?;
         let weekday = candidate_date.weekday();
 
-        // Only check weekdays
         if weekday != Weekday::Sat && weekday != Weekday::Sun {
-            // Check if the current day has the CLOSEST_WEEKDAY_BIT set
             if self.days.is_bit_set(day as u8, CLOSEST_WEEKDAY_BIT)? {
                 return Ok(true);
             }
-
-            // Check the previous and next days if the current day is a weekday
-            let previous_day = candidate_date - Duration::days(1);
-            let next_day = candidate_date + Duration::days(1);
-
-            let check_previous = previous_day.weekday() == Weekday::Sun
-                && self
-                    .days
-                    .is_bit_set(previous_day.day() as u8, CLOSEST_WEEKDAY_BIT)?;
-            let check_next = next_day.weekday() == Weekday::Sat
-                && self
-                    .days
-                    .is_bit_set(next_day.day() as u8, CLOSEST_WEEKDAY_BIT)?;
-            if check_previous || check_next {
+            let prev = candidate_date - Duration::days(1);
+            let next = candidate_date + Duration::days(1);
+            if (prev.weekday() == Weekday::Sun && self.days.is_bit_set(prev.day() as u8, CLOSEST_WEEKDAY_BIT)?)
+                || (next.weekday() == Weekday::Sat && self.days.is_bit_set(next.day() as u8, CLOSEST_WEEKDAY_BIT)?)
+            {
                 return Ok(true);
             }
         }
-
         Ok(false)
     }
 
-    // Checks if a given month matches the month part of the cron pattern.
     pub fn month_match(&self, month: u32) -> Result<bool, CronError> {
-        if month == 0 || month > 12 {
-            return Err(CronError::InvalidDate);
-        }
+        if !(1..=12).contains(&month) { return Err(CronError::InvalidDate); }
         self.months.is_bit_set(month as u8, ALL_BIT)
     }
 
-    // Checks if a given hour matches the hour part of the cron pattern.
     pub fn hour_match(&self, hour: u32) -> Result<bool, CronError> {
-        if hour > 23 {
-            return Err(CronError::InvalidTime);
-        }
+        if hour > 23 { return Err(CronError::InvalidTime); }
         self.hours.is_bit_set(hour as u8, ALL_BIT)
     }
 
-    // Checks if a given minute matches the minute part of the cron pattern.
     pub fn minute_match(&self, minute: u32) -> Result<bool, CronError> {
-        if minute > 59 {
-            return Err(CronError::InvalidTime);
-        }
+        if minute > 59 { return Err(CronError::InvalidTime); }
         self.minutes.is_bit_set(minute as u8, ALL_BIT)
     }
 
-    // Checks if a given second matches the second part of the cron pattern.
     pub fn second_match(&self, second: u32) -> Result<bool, CronError> {
-        if second > 59 {
-            return Err(CronError::InvalidTime);
-        }
+        if second > 59 { return Err(CronError::InvalidTime); }
         self.seconds.is_bit_set(second as u8, ALL_BIT)
     }
 
-    // Finds the next hour that matches the hour part of the cron pattern.
-    pub fn next_hour_match(&self, hour: u32) -> Result<Option<u32>, CronError> {
-        if hour > 23 {
-            return Err(CronError::InvalidTime);
+    /// Finds the next or previous matching value for a given time component based on direction.
+    pub fn find_match_in_component(
+        &self,
+        value: u32,
+        component_type: TimeComponent,
+        direction: Direction,
+    ) -> Result<Option<u32>, CronError> {
+        let component = match component_type {
+            TimeComponent::Second => &self.seconds,
+            TimeComponent::Minute => &self.minutes,
+            TimeComponent::Hour => &self.hours,
+            _ => return Err(CronError::ComponentError("Invalid component type for match search".to_string())),
+        };
+
+        let value_u8 = value as u8;
+        if value_u8 > component.max {
+            return Err(CronError::ComponentError(format!(
+                "Input value {} is out of bounds for the component (max: {}).",
+                value, component.max
+            )));
         }
-        for next_hour in hour..=23 {
-            if self.hours.is_bit_set(next_hour as u8, ALL_BIT)? {
-                return Ok(Some(next_hour));
+
+        match direction {
+            Direction::Forward => {
+                for next_value in value_u8..=component.max {
+                    if component.is_bit_set(next_value, ALL_BIT)? {
+                        return Ok(Some(next_value as u32));
+                    }
+                }
+            }
+            Direction::Backward => {
+                for prev_value in (component.min..=value_u8).rev() {
+                    if component.is_bit_set(prev_value, ALL_BIT)? {
+                        return Ok(Some(prev_value as u32));
+                    }
+                }
             }
         }
-        Ok(None) // No match found within the current range
+        Ok(None)
     }
 
-    // Finds the next minute that matches the minute part of the cron pattern.
-    pub fn next_minute_match(&self, minute: u32) -> Result<Option<u32>, CronError> {
-        if minute > 59 {
-            return Err(CronError::InvalidTime);
-        }
-        for next_minute in minute..=59 {
-            if self.minutes.is_bit_set(next_minute as u8, ALL_BIT)? {
-                return Ok(Some(next_minute));
-            }
-        }
-        Ok(None) // No match found within the current range
-    }
-
-    // Finds the next second that matches the second part of the cron pattern.
-    pub fn next_second_match(&self, second: u32) -> Result<Option<u32>, CronError> {
-        if second > 59 {
-            return Err(CronError::InvalidTime);
-        }
-        for next_second in second..=59 {
-            if self.seconds.is_bit_set(next_second as u8, ALL_BIT)? {
-                return Ok(Some(next_second));
-            }
-        }
-        Ok(None) // No match found within the current range
-    }
-
-    // Method to set the dom_and_dow flag
     pub fn with_dom_and_dow(&mut self) -> &mut Self {
         self.dom_and_dow = true;
         self
     }
 
-    // Method to set wether seconds should be allowed
     pub fn with_seconds_optional(&mut self) -> &mut Self {
         self.with_seconds_optional = true;
         self
     }
 
-    // Method to set wether seconds should be allowed
     pub fn with_seconds_required(&mut self) -> &mut Self {
         self.with_seconds_required = true;
         self
     }
 
-    // Method to set if weekdays should be offset by one (Quartz Scheduler style)
     pub fn with_alternative_weekdays(&mut self) -> &mut Self {
         self.with_alternative_weekdays = true;
-        //  We need to recreate self.days_of_week
         self.days_of_week = CronComponent::new(0, 7, LAST_BIT | NTH_ALL, 1);
         self
     }
 
-    // Get a reference to the original pattern
     pub fn as_str(&self) -> &str {
         &self.pattern
     }


### PR DESCRIPTION
* Adds public enum `Direction` (Forward, Backward)
* Adds public enum `TimeComponent` (Second, Minute, Hour, Day, Month, Year)
* Adds method `.iter_before` which iterate over runtimes *before* the time given.
* Adds parameter direction to `.iter_from`, allowing it to be used both for forward and backward iteration starting *from (and including)* the time given.
* Refactored by consolidating several internal functions making the codebase more manageable.
* Fixes #3 

Needs testing and review