### PR TITLE
Constrain w within month

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ a few additions and changes as outlined below:
 
 - Croner expressions have the following additional modifiers:
   - _?_: In the Rust version of croner, a questionmark in the day-of-month or 
-    day-of-week field behaves just as *. This allow for legacy cron patterns 
+    day-of-week field behaves just as `*`. This allow for legacy cron patterns 
     to be used.
   - _L_: The letter 'L' can be used in the day of the month field to indicate
     the last day of the month. When used in the day of the week field in
@@ -202,6 +202,11 @@ a few additions and changes as outlined below:
 > weekdays. For example, `5-6#L` means the last Friday and Saturday in the
 > month." The # character can be used to specify the "nth" weekday of the month.
 > For example, 5#2 represents the second Friday of the month.
+
+> **Note:** This feature is constrained within the given month. The search for 
+> the closest weekday will not cross into a previous or subsequent month. For
+> example, if the 1st of the month is a Saturday, 1W will trigger on Monday 
+> the 3rd, not the last Friday of the previous month.
 
 It is also possible to use the following "nicknames" as pattern.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1281,6 +1281,46 @@ mod tests {
     }
 
     #[test]
+    fn test_tabs_for_separator() -> Result<(), CronError> {
+        let cron = Cron::new("0 0   29  2   *").parse()?;
+        let leap_year_matching = Local.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap();
+
+        assert!(cron.is_time_matching(&leap_year_matching)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mixed_separators() -> Result<(), CronError> {
+        let cron = Cron::new("0  0    29  2      *").parse()?;
+        let leap_year_matching = Local.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap();
+
+        assert!(cron.is_time_matching(&leap_year_matching)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mixed_leading_separators() -> Result<(), CronError> {
+        let cron = Cron::new("  0 0 29 2 *").parse()?;
+        let leap_year_matching = Local.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap();
+
+        assert!(cron.is_time_matching(&leap_year_matching)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mixed_tailing_separators() -> Result<(), CronError> {
+        let cron = Cron::new("0 0 29 2 *    ").parse()?;
+        let leap_year_matching = Local.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap();
+
+        assert!(cron.is_time_matching(&leap_year_matching)?);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_time_overflow() -> Result<(), CronError> {
         let cron_match = Cron::new("59 59 23 31 12 *")
             .with_seconds_optional()

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -83,6 +83,11 @@ impl CronPattern {
         self.pattern = Self::replace_alpha_months(&self.pattern).to_string();
 
         // Check that the pattern contains 5 or 6 parts
+        // 
+        // split_whitespace() takes care of leading, trailing, and multiple 
+        // consequent whitespaces. The unicode definition of a whitespace 
+        // includes the ones commonly used in cron - 
+        // Space (U+0020) and Tab (U+0009).
         let mut parts: Vec<&str> = self.pattern.split_whitespace().collect();
         if parts.len() < 5 || parts.len() > 6 {
             return Err(CronError::InvalidPattern(String::from("Pattern must consist of five or six fields (minute, hour, day, month, day of week, and optional second).")));


### PR DESCRIPTION
Fixes a discrepancy where a date from another month matched if, for example, `1W` were used where the 1st is a saturday. Croner rust matched the last of the month before, instead of Monday the 3rd, like Quartz and other implementations of `W` use.