### PR TITLE
Reduce features of `chrono`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,13 @@ name = "croner"
 path = "src/lib.rs"
 
 [dependencies]
-chrono = "0.4.42"
+chrono = { version = "0.4.42", default-features = false }
 derive_builder = "0.20.2"
 serde = { version = "1.0", optional = true }
 strum = { version = "0.27.2", features = ["derive"] }
 
 [dev-dependencies]
+chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 chrono-tz = "0.10.4"
 criterion = "0.7.0"
 rstest = "0.26.1"


### PR DESCRIPTION
This disables default features of `chrono`, which are not necessary in normal builds. I've enabled `clock` in dev-dependencies since it's necessary for tests.