### PR TITLE
feat: derive `Eq` and `Ord` implementation for `Cron`

### DIFF
--- a/benches/croner_bench.rs
+++ b/benches/croner_bench.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use chrono::Local;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use croner::{parser::CronParser, Cron};
 
 fn parse_take_100(_n: u64) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,7 +43,7 @@ pub enum CronError {
     ComponentError(String),
 }
 impl std::fmt::Display for CronError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CronError::TimeSearchLimitExceeded => {
                 write!(f, "CronScheduler time search limit exceeded.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub const YEAR_LOWER_LIMIT: i32 = 1;
 
 // The Cron struct represents a cron schedule and provides methods to parse cron strings,
 // check if a datetime matches the cron pattern, and find the next occurrence.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Hash)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct Cron {
     pub pattern: CronPattern, // Parsed cron pattern
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,7 +859,7 @@ impl<'de> Deserialize<'de> for Cron {
         impl Visitor<'_> for CronVisitor {
             type Value = Cron;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a valid cron pattern")
             }
 


### PR DESCRIPTION
In #20 we implemented these traits for `CronPattern` but it looks like
we forgot to propagate this to the top-level `Cron` struct.
